### PR TITLE
refine ui theme and copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ uploads/
 data/
 tmp/
 
+# Design mockups (binary assets not tracked)
+mockups/
+
 # OS/Editor junk
 .DS_Store
 Thumbs.db

--- a/COPY_DECK.md
+++ b/COPY_DECK.md
@@ -1,0 +1,20 @@
+# Copy Deck
+
+## Labels
+- **Switch source:** Toggle between camera and upload.
+- **Import photo:** Opens image picker.
+- **Take photo:** Shutter button aria label.
+- **Create GIF:** Generates an animated GIF from captured photos.
+
+## Empty State
+- "Let’s make something. Take a photo or import one."
+
+## Progress
+- "Applying edit…"
+
+## Errors
+- "Model download failed. Retry • Manage storage."
+- "Error: [detail]. Retry."
+
+## Toasts
+- "Saved • Share."

--- a/COPY_DECK.md
+++ b/COPY_DECK.md
@@ -1,22 +1,93 @@
-# Copy Deck
+# GemBooth UI Copy Deck
 
-## Labels
-- Switch source — Camera/Upload toggle
-- Import — choose photo from device
-- Take photo — shutter button aria label
-- Create GIF — generates an animation from captured photos
-- Download — save image
-- Close — dismiss full view
+## Application Title
+- **Main Title**: Gembooth
 
-## Empty State
-- "Let’s make something. Take a photo or import one."
+## Navigation
+- **Capture**: Camera icon + "Capture"
+- **Gallery**: Photo library icon + "Gallery"
+- **Export**: Save icon + "Export"
 
-## Progress
-- "Applying edit… {pct}% • Cancel."
+## Capture Screen
+- **Shutter Button**: Camera icon (photo_camera)
+- **Source Toggle**: Switch camera icon (switch_camera)
+- **Upload Button**: Upload icon (upload)
+- **Modes Section Title**: "Styles"
+- **Custom Mode Toggle**: Edit icon (edit) + "Custom"
+- **Custom Prompt Placeholder**: "Describe your style..."
 
-## Errors
-- "Model download failed. Retry • Manage storage."
-- "Error: {detail}. Retry."
+## Gallery Screen
+- **Section Title**: "Gallery"
+- **Empty State Message**: "Let's make something. Take a photo or import one."
+- **Empty State Icon**: Photo library icon (photo_library)
+- **Back to Camera Button**: "Go to Camera"
+- **Select Mode Button**: Checklist icon (checklist)
 
-## Toasts
-- "Saved • Share."
+## Detail View
+- **Original Toggle**: Photo icon (photo) + "Original"
+- **Edited Toggle**: Auto awesome icon (auto_awesome) + "Edited"
+- **Download Button**: Download icon (download)
+
+## Export Screen
+- **Section Title**: "Export"
+- **Size Section Title**: "Size"
+- **Size Options**: 
+  - Small
+  - Medium
+  - Large
+- **Metadata Section Title**: "Metadata"
+- **Location Toggle**: "Include location data"
+- **Timestamp Toggle**: "Include timestamp"
+- **Export Button**: Download icon (download) + "Save to Photos"
+
+## Modes (from backend)
+1. **Renaissance**: 🎨 + "Renaissance"
+2. **Cartoon**: 😃 + "Cartoon"
+3. **Statue**: 🏛️ + "Statue"
+4. **80s**: ✨ + "80s"
+5. **19th Cent.**: 🎩 + "19th Cent."
+6. **Anime**: 🍣 + "Anime"
+7. **Psychedelic**: 🌈 + "Psychedelic"
+8. **8-bit**: 🎮 + "8-bit"
+9. **Big Beard**: 🧔🏻 + "Big Beard"
+10. **Comic Book**: 💥 + "Comic Book"
+11. **Old**: 👵🏻 + "Old"
+12. **Custom**: ✏️ + "Custom"
+
+## Toast Messages
+- **Success**: "Image generated successfully!"
+- **Download Success**: "Image downloaded!"
+- **Upload Error**: "Please choose an image to upload"
+- **Generic Error**: "Something went wrong. Please try again."
+- **API Error**: "Model download failed. Retry • Manage storage"
+
+## Progress Messages
+- **Processing**: "Applying edit..."
+- **Percentage**: "68%"
+
+## Progress Actions
+- **Cancel**: "Cancel"
+
+## Accessibility Labels
+- **Shutter Button**: "Take photo"
+- **Source Toggle**: "Switch source"
+- **Upload Button**: "Import photo"
+- **Mode Selection**: "Style"
+- **Custom Prompt**: "Custom prompt"
+- **Detail Close**: "Close"
+- **Detail Download**: "Download"
+- **Toast Close**: "Close notification"
+
+## Error States
+- **Empty Gallery**: "Let's make something. Take a photo or import one."
+- **API Error**: "Model download failed. Retry • Manage storage"
+- **Generic Error**: "Error: [error message]. Retry."
+- **No Image Returned**: "No image returned by model. Retry."
+
+## Success States
+- **Image Generated**: "Image generated successfully!"
+- **Image Downloaded**: "Saved to Photos"
+- **GIF Created**: "GIF created successfully!"
+
+## Loading States
+- **Applying Edit**: "Applying edit… 68% • Cancel"

--- a/COPY_DECK.md
+++ b/COPY_DECK.md
@@ -1,20 +1,22 @@
 # Copy Deck
 
 ## Labels
-- **Switch source:** Toggle between camera and upload.
-- **Import photo:** Opens image picker.
-- **Take photo:** Shutter button aria label.
-- **Create GIF:** Generates an animated GIF from captured photos.
+- Switch source — Camera/Upload toggle
+- Import — choose photo from device
+- Take photo — shutter button aria label
+- Create GIF — generates an animation from captured photos
+- Download — save image
+- Close — dismiss full view
 
 ## Empty State
 - "Let’s make something. Take a photo or import one."
 
 ## Progress
-- "Applying edit…"
+- "Applying edit… {pct}% • Cancel."
 
 ## Errors
 - "Model download failed. Retry • Manage storage."
-- "Error: [detail]. Retry."
+- "Error: {detail}. Retry."
 
 ## Toasts
 - "Saved • Share."

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,116 @@
+# GemBooth Project Context
+
+## Project Overview
+
+GemBooth is a Flask-based web application that functions as an AI-powered photobooth. Users can capture photos from their webcam or upload existing images, which are then transformed using various artistic styles through the OpenRouter API.
+
+### Key Features
+- Webcam photo capture or file upload
+- Multiple preset artistic styles (Renaissance, Cartoon, Anime, etc.)
+- Custom prompt support for personalized transformations
+- Generated images saved and displayed in a gallery
+- Ability to create animated GIFs from original/generated image pairs
+
+### Technologies Used
+- **Backend**: Python Flask
+- **Frontend**: HTML, CSS, JavaScript
+- **API Integration**: OpenRouter API (using OpenAI Python client)
+- **Image Processing**: Pillow library
+- **Environment Management**: python-dotenv
+
+## Project Structure
+
+```
+fun_image_gen/
+├── app.py              # Main Flask application
+├── requirements.txt    # Python dependencies
+├── test.py             # API connectivity test script
+├── metadata.json       # Web app metadata with camera permissions
+├── README.md           # Project documentation
+├── .gitignore          # Git ignore rules
+├── static/             # Static assets
+│   ├── style.css       # Main styles
+│   ├── theme.css       # Theme and design tokens
+│   └── generated_images/  # Storage for processed images (git-ignored)
+├── templates/          # HTML templates
+│   └── index.html      # Main application page
+└── venv/               # Python virtual environment (git-ignored)
+```
+
+## Setup and Configuration
+
+### Dependencies
+Install required packages:
+```bash
+pip install -r requirements.txt
+```
+
+Key dependencies:
+- Flask (web framework)
+- openai (OpenRouter API client)
+- python-dotenv (environment variable management)
+- Pillow (image processing)
+
+### Environment Variables
+Create a `.env` file with the following required variable:
+```
+OPENROUTER_API_KEY=your_api_key_here
+```
+
+Optional variables:
+- `SITE_URL`: HTTP referer header for API calls
+- `SITE_TITLE`: Attribution title (defaults to "Gembooth")
+- `IMAGE_MODEL`: Model name (defaults to "google/gemini-2.5-flash-image-preview:free")
+
+## Running the Application
+
+1. Install dependencies and set up `.env` file
+2. Start the Flask server:
+   ```bash
+   python app.py
+   ```
+3. Access the application at http://localhost:5000
+
+## Testing
+
+Run the API connectivity test:
+```bash
+python test.py
+```
+
+## Development Notes
+
+### Code Structure
+- **app.py**: Contains all Flask routes and image processing logic
+- **Frontend**: Single-page application with camera controls, style selection, and gallery
+- **Styling**: CSS custom properties (design tokens) for consistent theming
+- **Image Storage**: Images saved to `static/generated_images/` during runtime
+
+### Predefined Styles
+The application includes 11 predefined artistic styles with custom prompts:
+1. Renaissance
+2. Cartoon
+3. Statue
+4. 80s
+5. 19th Century
+6. Anime
+7. Psychedelic
+8. 8-bit
+9. Big Beard
+10. Comic Book
+11. Old
+
+### Image Processing Flow
+1. Capture/upload image
+2. Save original image locally
+3. Send image + prompt to OpenRouter API
+4. Receive transformed image
+5. Save generated image locally
+6. Display in gallery with original
+
+## Important Directories and Files
+
+- `static/generated_images/`: Runtime storage for all processed images (git-ignored)
+- `templates/index.html`: Main UI with all frontend logic
+- `static/style.css` and `static/theme.css`: Complete styling with design tokens
+- `app.py`: Core application logic including Flask routes and OpenRouter integration

--- a/UI_OVERHAUL.md
+++ b/UI_OVERHAUL.md
@@ -1,0 +1,90 @@
+# GemBooth UI/UX Overhaul
+
+This document describes the complete UI/UX overhaul of the GemBooth application with the following improvements:
+
+## Key Improvements
+
+### 1. Modern Design System
+- Updated theme with improved color palette for both light and dark modes
+- Consistent spacing using 8pt grid system
+- Unified component styles with proper states (hover, active, focus, disabled)
+- Improved typography hierarchy
+- Enhanced accessibility with proper contrast ratios (≥4.5:1)
+
+### 2. Enhanced User Experience
+- Simplified navigation with tab bar
+- Improved capture screen with dominant preview and clear controls
+- Better mode selection with chip-based interface
+- Enhanced gallery view with grid layout
+- Detailed image view with before/after toggle
+- Export screen with size and metadata options
+
+### 3. Mobile-First Design
+- Optimized for one-hand reach with appropriately sized tap targets (minimum 44×44px)
+- Responsive layouts for different screen sizes
+- Improved touch interactions with visual feedback
+- Reduced learning curve with intuitive interface
+
+### 4. Accessibility Features
+- Proper focus order and labels for all interactive elements
+- Sufficient color contrast for readability
+- Support for screen readers with ARIA attributes
+- Respect for "reduce motion" preferences
+
+## Design Tokens
+
+The overhaul introduces a comprehensive design system with the following tokens:
+
+### Colors
+- Primary brand color: `#ff6b2c` (Orange)
+- Dark theme with proper contrast ratios
+- Light theme option
+- Semantic colors for success, warning, and error states
+
+### Spacing
+- 8pt grid system with scales from 0px to 64px
+- Consistent spacing throughout the interface
+
+### Typography
+- Clear hierarchy with Display, Title, Section, Body, and Caption levels
+- Proper line heights and weights for readability
+
+### Components
+- Buttons with primary, secondary, and danger variants
+- Chips for mode selection
+- Sliders with proper labeling
+- Toggle switches
+- Toast notifications
+- Progress indicators
+- Segmented controls
+
+## Screens
+
+### 1. Capture Screen
+- Dominant live preview area
+- Large, accessible shutter button
+- Clear source toggle (camera/upload)
+- Mode selection chips with emoji icons
+- Custom prompt input when needed
+
+### 2. Gallery Screen
+- Grid-based layout for photos
+- Empty state with clear call-to-action
+- Visual badges for applied styles
+- Detailed view with before/after toggle
+
+### 3. Export Screen
+- Size selection with segmented controls
+- Metadata toggle options
+- Primary export action button
+
+## Implementation Notes
+
+The UI overhaul maintains all existing functionality while providing a significantly improved user experience with a modern, accessible design. All changes have been integrated directly into the existing files:
+
+1. `static/theme.css` - Updated design tokens and component styles
+2. `static/style.css` - Updated layout and screen-specific styles
+3. `templates/index.html` - Updated HTML template with new UI structure
+4. `COPY_DECK.md` - Complete copy deck for all UI text
+
+The application can be run as before with `python app.py` and will now use the new UI.

--- a/static/style.css
+++ b/static/style.css
@@ -1,329 +1,56 @@
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-* ::selection {
-  background: var(--color-text);
-  color: var(--color-bg);
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-weight: 400;
-}
-li {
-  list-style: none;
-}
-input,
-textarea {
-  font: var(--font-body);
-  background: none;
-  color: var(--color-text);
-  border: none;
-  outline: none;
-  font-size: 16px;
-  resize: none;
-  -webkit-user-select: text;
-  user-select: text;
-}
-input::placeholder,
-textarea::placeholder {
-  -webkit-user-select: none;
-  user-select: none;
-}
-select {
-  appearance: none;
-  font: var(--font-body);
-  padding: var(--space-2);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  cursor: pointer;
-  min-height: 44px;
-}
-button {
-  font: var(--font-body);
-  background: none;
-  color: var(--color-text);
-  border: none;
-  font-size: 16px;
-  cursor: pointer;
-  -webkit-user-select: none;
-  user-select: none;
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-}
-button:focus {
-  outline: none;
-}
-button[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-button .icon {
-  display: block;
-}
-.icon {
-  font-family: Material Symbols Outlined;
-  font-weight: 300;
-  line-height: 1;
-}
-main {
-  width: 100vw;
-  height: 100dvh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-.video-container {
-  overflow: hidden;
-  position: relative;
-  flex: 1;
-  background: var(--color-bg);
-}
-.video-container video {
-  display: block;
-  margin: 0 auto;
-  height: 100%;
-  max-width: 100%;
-  object-fit: cover;
-  transition: filter 0.2s;
-  transform: rotateY(180deg);
-  aspect-ratio: 1;
-}
+/* Layout and component styling for the overhauled UI */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+html,body{height:100%;}
+::selection{background:var(--color-text);color:var(--color-bg);}
+body{display:flex;flex-direction:column;background:var(--color-bg);color:var(--color-text);font:var(--font-body);}
+main{flex:1;display:flex;flex-direction:column;}
 
-.shutter {
-  background: var(--color-surface);
-  border: 3px solid var(--color-primary);
-  border-radius: 50%;
-  width: 88px;
-  height: 88px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.6));
-  transition: transform .2s, background-color .2s;
-  position: absolute;
-  bottom: var(--space-5);
-  left: 50%;
-  transform: translateX(-50%);
-}
-.shutter::before {
-  content: '';
-  position: absolute;
-  inset: -6px;
-  border-radius: 50%;
-  border: 3px solid var(--color-primary);
-  opacity: 0.3;
-}
-.shutter .icon {
-  font-size: 40px;
-  color: var(--color-primary);
-  transition: color .2s;
-}
-.shutter:hover {
-  transform: translateX(-50%) scale(1.07);
-}
-.shutter:active {
-  transform: translateX(-50%) scale(0.93);
-}
+/* Preview area */
+.preview{position:relative;flex:1;overflow:hidden;background:var(--color-bg);}
+.preview video{width:100%;height:100%;object-fit:cover;transform:rotateY(180deg);transition:filter .2s;}
+.preview #upload-preview{display:none;max-width:100%;max-height:100%;object-fit:contain;}
 
-.controls {
-    display: flex;
-    justify-content: center;
-    padding: var(--space-2);
-    background: var(--color-surface);
-}
+/* Shutter */
+.shutter{position:absolute;bottom:var(--space-5);left:50%;transform:translateX(-50%);width:96px;height:96px;border-radius:50%;background:var(--color-surface);border:4px solid var(--color-primary);display:flex;align-items:center;justify-content:center;box-shadow:0 4px 12px rgba(0,0,0,.6);transition:transform .15s,background .15s;}
+.shutter::after{content:'';position:absolute;inset:-8px;border-radius:50%;border:4px solid var(--color-primary);opacity:.2;}
+.shutter .icon{font-size:48px;color:var(--color-primary);}
+.shutter:hover{transform:translateX(-50%) scale(1.05);}
+.shutter:active{transform:translateX(-50%) scale(.93);}
 
-.results {
-  display: flex;
-  position: relative;
-  height: clamp(200px, 25dvh, 300px);
-  border-top: 1px solid var(--color-border);
-  padding: var(--space-3);
-  overflow: auto;
-  background: var(--color-surface);
-}
-.results ul {
-  display: flex;
-  gap: var(--space-2);
-}
+/* Source controls */
+.source-controls{position:absolute;top:var(--space-3);left:var(--space-3);display:flex;gap:var(--space-2);}
+.source-controls label{cursor:pointer;}
+.source-controls label,.source-controls button{min-width:44px;}
 
-.results .empty {
-  font: var(--font-body);
-  color: var(--color-text);
-  opacity: 0.7;
-}
+/* Mode controls */
+.controls{display:flex;gap:var(--space-2);padding:var(--space-3);background:var(--color-surface);align-items:center;justify-content:center;border-top:1px solid var(--color-border);}
+.controls select,.controls textarea{background:var(--color-bg);color:var(--color-text);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-2);min-height:44px;}
+.controls select{width:160px;}
+.controls textarea{flex:1;}
 
-.results li {
-  aspect-ratio: 1;
-  height: 100%;
-  transition: opacity 0.3s;
-  position: relative;
-  display: flex;
-  gap: var(--space-1);
-}
+/* Gallery */
+.gallery{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3);overflow-x:auto;}
+.gallery ul{display:flex;gap:var(--space-3);}
+.gallery li{position:relative;width:120px;height:120px;flex:none;border-radius:var(--radius-sm);overflow:hidden;border:1px solid var(--color-border);display:flex;}
+.gallery li img{width:100%;height:100%;object-fit:cover;}
+.gallery li .photo{flex:1;}
+.gallery .empty{font:var(--font-body);opacity:.6;}
+.gallery li.isBusy img{filter:brightness(.4);}
+.gallery li.isBusy::before{content:'';position:absolute;inset:0;background:linear-gradient(90deg,transparent,rgba(255,255,255,.15),transparent);background-size:200% 100%;animation:shimmer 2s infinite;}
+.gallery li.isBusy::after{content:'Applying edit…';position:absolute;bottom:var(--space-2);left:50%;transform:translateX(-50%);font:var(--font-caption);color:var(--color-on-primary);}
+.photo-actions{position:absolute;bottom:var(--space-1);right:var(--space-1);display:flex;gap:var(--space-1);}
 
-.results li .photo {
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  border: 1px solid var(--color-border);
-  width: 100%;
-  height: 100%;
-  cursor: pointer;
-}
+/* Export */
+.export{padding:var(--space-3);text-align:center;background:var(--color-surface);border-top:1px solid var(--color-border);}
+#gif-result img{max-width:100%;}
 
-.results li img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
+/* Lightbox */
+.lightbox{position:fixed;inset:0;background:rgba(0,0,0,.9);display:none;align-items:center;justify-content:center;z-index:100;}
+.lightbox.is-open{display:flex;}
+.lightbox img{max-width:92vw;max-height:92vh;border-radius:var(--radius-lg);box-shadow:var(--elevation-3);}
+.lightbox-close{position:absolute;top:var(--space-3);right:var(--space-3);width:44px;height:44px;border-radius:50%;background:var(--color-bg);border:1px solid var(--color-border);color:var(--color-text);display:flex;align-items:center;justify-content:center;font-size:24px;}
+.lightbox-actions{position:absolute;bottom:var(--space-4);display:flex;gap:var(--space-2);}
 
-.results li.isBusy {
-  position: relative;
-}
-.results li.isBusy img {
-  filter: brightness(0.4);
-}
-.results li.isBusy:before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.2) 25%,
-    rgba(255, 255, 255, 0.3) 50%,
-    rgba(255, 255, 255, 0.2) 75%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 2s infinite ease-in-out;
-  z-index: 1;
-  pointer-events: none;
-}
-.results li.isBusy:after {
-  content: 'Applying edit…';
-  position: absolute;
-  bottom: var(--space-2);
-  left: 50%;
-  transform: translateX(-50%);
-  color: var(--color-on-primary);
-  font: var(--font-caption);
-  z-index: 2;
-}
+@keyframes shimmer{0%{background-position:-200% 0;}100%{background-position:200% 0;}}
 
-.gif-container {
-    padding: var(--space-2);
-    text-align: center;
-    background: var(--color-surface);
-}
-
-#make-gif {
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius-md);
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -200% 0;
-  }
-  to {
-    background-position: 200% 0;
-  }
-}
-
-/* Lightbox overlay for full image view */
-.lightbox {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.9);
-  z-index: 9999;
-  display: none;
-  align-items: center;
-  justify-content: center;
-}
-.lightbox.is-open { display: flex; }
-.lightbox img {
-  max-width: 92vw;
-  max-height: 92vh;
-  border-radius: var(--radius-md);
-  box-shadow: var(--elevation-3);
-}
-.lightbox-close {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  color: var(--color-text);
-  border-radius: 50%;
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 24px;
-}
-.lightbox-actions {
-  position: absolute;
-  bottom: var(--space-3);
-  display: flex;
-  gap: var(--space-2);
-}
-
-/* Quick actions on photo */
-.photo-actions {
-  position: absolute;
-  bottom: var(--space-1);
-  right: var(--space-1);
-  display: flex;
-  gap: var(--space-1);
-}
-
-/* Modal styles */
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 100;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgba(0,0,0,0.9);
-}
-
-.modal-content {
-  margin: auto;
-  display: block;
-  width: 80%;
-  max-width: 700px;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.close {
-  position: absolute;
-  top: var(--space-2);
-  right: var(--space-4);
-  color: var(--color-text);
-  font-size: 40px;
-  font-weight: bold;
-  transition: 0.3s;
-}
-
-.close:hover,
-.close:focus {
-  color: var(--color-border);
-  text-decoration: none;
-  cursor: pointer;
-}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important;}}

--- a/static/style.css
+++ b/static/style.css
@@ -4,16 +4,8 @@
   box-sizing: border-box;
 }
 * ::selection {
-  background: #fff;
-  color: #111;
-}
-:root {
-  background: #000;
-  color: #fff;
-  font-family:
-    Space Mono,
-    Google Sans Display,
-    sans-serif;
+  background: var(--color-text);
+  color: var(--color-bg);
 }
 h1,
 h2,
@@ -28,15 +20,12 @@ li {
 }
 input,
 textarea {
-  font-family:
-    Space Mono,
-    Google Sans Display,
-    sans-serif;
+  font: var(--font-body);
   background: none;
-  color: #fff;
+  color: var(--color-text);
   border: none;
   outline: none;
-  font-size: 18px;
+  font-size: 16px;
   resize: none;
   -webkit-user-select: text;
   user-select: text;
@@ -48,21 +37,19 @@ textarea::placeholder {
 }
 select {
   appearance: none;
-  font-family: inherit;
-  padding: 10px;
-  background: #111;
-  color: #fff;
-  border-radius: 4px;
-  font-size: 16px;
+  font: var(--font-body);
+  padding: var(--space-2);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
   cursor: pointer;
+  min-height: 44px;
 }
 button {
-  font-family:
-    Space Mono,
-    Google Sans Display,
-    sans-serif;
+  font: var(--font-body);
   background: none;
-  color: #fff;
+  color: var(--color-text);
   border: none;
   font-size: 16px;
   cursor: pointer;
@@ -70,7 +57,7 @@ button {
   user-select: none;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-1);
 }
 button:focus {
   outline: none;
@@ -81,15 +68,6 @@ button[disabled] {
 }
 button .icon {
   display: block;
-}
-.button {
-  display: inline-flex;
-  padding: 10px;
-  border-radius: 8px;
-  gap: 4px;
-  align-items: center;
-  justify-content: center;
-  color: #fffc;
 }
 .icon {
   font-family: Material Symbols Outlined;
@@ -107,7 +85,7 @@ main {
   overflow: hidden;
   position: relative;
   flex: 1;
-  background-image: linear-gradient(to bottom, #000, #111);
+  background-image: linear-gradient(to bottom, var(--color-bg), var(--color-surface));
 }
 .video-container video {
   display: block;
@@ -121,53 +99,65 @@ main {
 }
 
 .shutter {
-  background: #000000b3;
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background: var(--color-surface);
+  border: 2px solid var(--color-primary);
   border-radius: 50%;
-  padding: 10px;
-  filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.5));
-  transition: all 0.2s;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.5));
+  transition: transform .2s, background-color .2s;
   position: absolute;
-  bottom: 20px;
+  bottom: var(--space-4);
   left: 50%;
   transform: translateX(-50%);
 }
+.shutter::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid var(--color-primary);
+  opacity: 0.4;
+}
 .shutter .icon {
-  font-size: 42px;
-  color: #ddd;
-  transition: color 0.2s;
+  font-size: 36px;
+  color: var(--color-primary);
+  transition: color .2s;
 }
 .shutter:hover {
-  scale: 1.1;
-}
-.shutter:hover .icon {
-  color: #fff;
+  transform: translateX(-50%) scale(1.05);
 }
 .shutter:active {
-  scale: 0.8;
-  rotate: 10deg;
+  transform: translateX(-50%) scale(0.95);
 }
 
 .controls {
     display: flex;
     justify-content: center;
-    padding: 10px;
-    background: #111;
+    padding: var(--space-2);
+    background: var(--color-surface);
 }
 
 .results {
   display: flex;
   position: relative;
   height: clamp(200px, 25dvh, 300px);
-  border-top: 1px solid #333;
-  padding: 15px;
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-3);
   overflow: auto;
-  background: #111;
+  background: var(--color-surface);
 }
 .results ul {
   display: flex;
-  gap: 10px;
+  gap: var(--space-2);
+}
+
+.results .empty {
+  font: var(--font-body);
+  color: var(--color-text);
 }
 
 .results li {
@@ -176,13 +166,13 @@ main {
   transition: opacity 0.3s;
   position: relative;
   display: flex;
-  gap: 5px;
+  gap: var(--space-1);
 }
 
 .results li .photo {
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--color-border);
   width: 100%;
   height: 100%;
   cursor: pointer;
@@ -217,19 +207,26 @@ main {
   z-index: 1;
   pointer-events: none;
 }
+.results li.isBusy:after {
+  content: 'Applying edit…';
+  position: absolute;
+  bottom: var(--space-2);
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--color-on-primary);
+  font: var(--font-caption);
+  z-index: 2;
+}
 
 .gif-container {
-    padding: 10px;
+    padding: var(--space-2);
     text-align: center;
-    background: #111;
+    background: var(--color-surface);
 }
 
 #make-gif {
-    background: #e64a19;
-    border: 2px solid #fff;
-    color: #fff;
-    padding: 10px 20px;
-    border-radius: 5px;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
 }
 
 @keyframes shimmer {
@@ -255,19 +252,19 @@ main {
 .lightbox img {
   max-width: 92vw;
   max-height: 92vh;
-  border-radius: 8px;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.6);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-3);
 }
 .lightbox-close {
   position: absolute;
-  top: 16px;
-  right: 16px;
-  background: #000000b3;
-  border: 1px solid #444;
-  color: #fff;
-  border-radius: 999px;
-  width: 40px;
-  height: 40px;
+  top: var(--space-3);
+  right: var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -275,18 +272,18 @@ main {
 }
 .lightbox-actions {
   position: absolute;
-  bottom: 20px;
+  bottom: var(--space-3);
   display: flex;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 /* Quick actions on photo */
 .photo-actions {
   position: absolute;
-  bottom: 6px;
-  right: 6px;
+  bottom: var(--space-1);
+  right: var(--space-1);
   display: flex;
-  gap: 6px;
+  gap: var(--space-1);
 }
 
 /* Modal styles */
@@ -315,9 +312,9 @@ main {
 
 .close {
   position: absolute;
-  top: 15px;
-  right: 35px;
-  color: #f1f1f1;
+  top: var(--space-2);
+  right: var(--space-4);
+  color: var(--color-text);
   font-size: 40px;
   font-weight: bold;
   transition: 0.3s;
@@ -325,7 +322,7 @@ main {
 
 .close:hover,
 .close:focus {
-  color: #bbb;
+  color: var(--color-border);
   text-decoration: none;
   cursor: pointer;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -85,7 +85,7 @@ main {
   overflow: hidden;
   position: relative;
   flex: 1;
-  background-image: linear-gradient(to bottom, var(--color-bg), var(--color-surface));
+  background: var(--color-bg);
 }
 .video-container video {
   display: block;
@@ -100,38 +100,38 @@ main {
 
 .shutter {
   background: var(--color-surface);
-  border: 2px solid var(--color-primary);
+  border: 3px solid var(--color-primary);
   border-radius: 50%;
-  width: 72px;
-  height: 72px;
+  width: 88px;
+  height: 88px;
   display: flex;
   align-items: center;
   justify-content: center;
-  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.5));
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.6));
   transition: transform .2s, background-color .2s;
   position: absolute;
-  bottom: var(--space-4);
+  bottom: var(--space-5);
   left: 50%;
   transform: translateX(-50%);
 }
 .shutter::before {
   content: '';
   position: absolute;
-  inset: -4px;
+  inset: -6px;
   border-radius: 50%;
-  border: 2px solid var(--color-primary);
-  opacity: 0.4;
+  border: 3px solid var(--color-primary);
+  opacity: 0.3;
 }
 .shutter .icon {
-  font-size: 36px;
+  font-size: 40px;
   color: var(--color-primary);
   transition: color .2s;
 }
 .shutter:hover {
-  transform: translateX(-50%) scale(1.05);
+  transform: translateX(-50%) scale(1.07);
 }
 .shutter:active {
-  transform: translateX(-50%) scale(0.95);
+  transform: translateX(-50%) scale(0.93);
 }
 
 .controls {
@@ -158,6 +158,7 @@ main {
 .results .empty {
   font: var(--font-body);
   color: var(--color-text);
+  opacity: 0.7;
 }
 
 .results li {

--- a/static/style.css
+++ b/static/style.css
@@ -1,56 +1,686 @@
-/* Layout and component styling for the overhauled UI */
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
-html,body{height:100%;}
-::selection{background:var(--color-text);color:var(--color-bg);}
-body{display:flex;flex-direction:column;background:var(--color-bg);color:var(--color-text);font:var(--font-body);}
-main{flex:1;display:flex;flex-direction:column;}
+/* Main Styles for GemBooth UI Overhaul */
 
-/* Preview area */
-.preview{position:relative;flex:1;overflow:hidden;background:var(--color-bg);}
-.preview video{width:100%;height:100%;object-fit:cover;transform:rotateY(180deg);transition:filter .2s;}
-.preview #upload-preview{display:none;max-width:100%;max-height:100%;object-fit:contain;}
+/* Layout */
+*, 
+*::before, 
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
-/* Shutter */
-.shutter{position:absolute;bottom:var(--space-5);left:50%;transform:translateX(-50%);width:96px;height:96px;border-radius:50%;background:var(--color-surface);border:4px solid var(--color-primary);display:flex;align-items:center;justify-content:center;box-shadow:0 4px 12px rgba(0,0,0,.6);transition:transform .15s,background .15s;}
-.shutter::after{content:'';position:absolute;inset:-8px;border-radius:50%;border:4px solid var(--color-primary);opacity:.2;}
-.shutter .icon{font-size:48px;color:var(--color-primary);}
-.shutter:hover{transform:translateX(-50%) scale(1.05);}
-.shutter:active{transform:translateX(-50%) scale(.93);}
+html, 
+body {
+  height: 100%;
+  overflow: hidden;
+}
 
-/* Source controls */
-.source-controls{position:absolute;top:var(--space-3);left:var(--space-3);display:flex;gap:var(--space-2);}
-.source-controls label{cursor:pointer;}
-.source-controls label,.source-controls button{min-width:44px;}
+body {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: var(--font-body);
+  font-feature-settings: "liga" 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
-/* Mode controls */
-.controls{display:flex;gap:var(--space-2);padding:var(--space-3);background:var(--color-surface);align-items:center;justify-content:center;border-top:1px solid var(--color-border);}
-.controls select,.controls textarea{background:var(--color-bg);color:var(--color-text);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-2);min-height:44px;}
-.controls select{width:160px;}
-.controls textarea{flex:1;}
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+/* Header */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  z-index: 10;
+}
+
+.app-title {
+  font: var(--font-title);
+  color: var(--color-text);
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* Main Content */
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Capture Screen */
+.capture-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--duration-medium) var(--easing-decelerate),
+              transform var(--duration-medium) var(--easing-decelerate);
+}
+
+.preview-container {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--color-bg);
+}
+
+.preview-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: rotateY(180deg);
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: none;
+}
+
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Capture Controls */
+.capture-controls {
+  position: absolute;
+  bottom: var(--space-5);
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-5);
+  z-index: 10;
+}
+
+.shutter-button {
+  width: var(--size-shutter);
+  height: var(--size-shutter);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  border: 4px solid var(--color-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--elevation-3);
+  cursor: pointer;
+  transition: 
+    transform var(--duration-fast) var(--easing-standard),
+    box-shadow var(--duration-fast) var(--easing-standard);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.shutter-button:hover {
+  transform: scale(1.05);
+}
+
+.shutter-button:active {
+  transform: scale(0.95);
+}
+
+.shutter-button:focus-visible {
+  box-shadow: var(--focus-ring), var(--elevation-3);
+}
+
+.shutter-button .icon {
+  font-size: 32px;
+  color: var(--color-primary);
+}
+
+.shutter-button--retake {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.shutter-button--retake .icon {
+  color: var(--color-on-primary);
+}
+
+.capture-actions {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  display: flex;
+  gap: var(--space-2);
+  z-index: 10;
+}
+
+/* Mode Selection */
+.mode-selection {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-3);
+  /* Extra bottom padding so horizontal scrollbar doesn't collide with bottom nav */
+  padding-bottom: calc(var(--space-3) + 10px);
+  /* Create breathing room above bottom nav so overlay scrollbars don't visually overlap */
+  margin-bottom: var(--space-3);
+}
+
+.mode-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-3);
+}
+
+.mode-title {
+  font: var(--font-section);
+  color: var(--color-text);
+}
+
+.mode-toggle {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font: var(--font-button);
+  cursor: pointer;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.mode-toggle:hover {
+  text-decoration: underline;
+}
+
+.mode-chips {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: var(--space-2) var(--space-4);
+  /* Add extra bottom padding so OS overlay scrollbars don't touch content */
+  padding-bottom: calc(var(--space-2) + 12px);
+  /* Keep first/last chip from being cut off and reserve room for scrollbar */
+  scroll-padding-inline: var(--space-3);
+  scrollbar-gutter: stable both-edges;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+}
+
+/* Virtual gutters so the first/last chip never get clipped at the edges */
+.mode-chips::before,
+.mode-chips::after {
+  content: "";
+  flex: 0 0 var(--space-4);
+}
+
+/* Ensure the very first/last chip has breathing room on platforms that ignore ::before/::after in scroll width */
+.mode-chip:first-child { margin-left: var(--space-9); }
+
+/* Snap chips cleanly to the left edge when scrolling */
+.mode-chip { scroll-snap-align: start; }
+
+.mode-chip {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.mode-chip .icon {
+  margin-right: var(--space-1);
+}
+
+/* Custom Prompt */
+.custom-prompt-container {
+  margin-top: var(--space-3);
+  display: none;
+}
+
+.custom-prompt-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: var(--space-2);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font: var(--font-body);
+  resize: vertical;
+}
+
+.custom-prompt-textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary);
+}
 
 /* Gallery */
-.gallery{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3);overflow-x:auto;}
-.gallery ul{display:flex;gap:var(--space-3);}
-.gallery li{position:relative;width:120px;height:120px;flex:none;border-radius:var(--radius-sm);overflow:hidden;border:1px solid var(--color-border);display:flex;}
-.gallery li img{width:100%;height:100%;object-fit:cover;}
-.gallery li .photo{flex:1;}
-.gallery .empty{font:var(--font-body);opacity:.6;}
-.gallery li.isBusy img{filter:brightness(.4);}
-.gallery li.isBusy::before{content:'';position:absolute;inset:0;background:linear-gradient(90deg,transparent,rgba(255,255,255,.15),transparent);background-size:200% 100%;animation:shimmer 2s infinite;}
-.gallery li.isBusy::after{content:'Applying edit…';position:absolute;bottom:var(--space-2);left:50%;transform:translateX(-50%);font:var(--font-caption);color:var(--color-on-primary);}
-.photo-actions{position:absolute;bottom:var(--space-1);right:var(--space-1);display:flex;gap:var(--space-1);}
+.gallery-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--duration-medium) var(--easing-decelerate),
+              transform var(--duration-medium) var(--easing-decelerate);
+}
 
-/* Export */
-.export{padding:var(--space-3);text-align:center;background:var(--color-surface);border-top:1px solid var(--color-border);}
-#gif-result img{max-width:100%;}
+.gallery-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
 
-/* Lightbox */
-.lightbox{position:fixed;inset:0;background:rgba(0,0,0,.9);display:none;align-items:center;justify-content:center;z-index:100;}
-.lightbox.is-open{display:flex;}
-.lightbox img{max-width:92vw;max-height:92vh;border-radius:var(--radius-lg);box-shadow:var(--elevation-3);}
-.lightbox-close{position:absolute;top:var(--space-3);right:var(--space-3);width:44px;height:44px;border-radius:50%;background:var(--color-bg);border:1px solid var(--color-border);color:var(--color-text);display:flex;align-items:center;justify-content:center;font-size:24px;}
-.lightbox-actions{position:absolute;bottom:var(--space-4);display:flex;gap:var(--space-2);}
+.gallery-title {
+  font: var(--font-section);
+  color: var(--color-text);
+}
 
-@keyframes shimmer{0%{background-position:-200% 0;}100%{background-position:200% 0;}}
+.gallery-actions {
+  display: flex;
+  gap: var(--space-2);
+}
 
-@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important;}}
+.gallery-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+}
+
+.gallery-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  height: 100%;
+  padding: var(--space-4);
+  color: var(--color-text-secondary);
+}
+
+.gallery-empty .icon {
+  font-size: 48px;
+  margin-bottom: var(--space-3);
+  color: var(--color-border-strong);
+}
+
+.gallery-empty-text {
+  font: var(--font-body);
+  margin-bottom: var(--space-4);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-3);
+}
+
+.gallery-item {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  background: var(--color-bg-secondary);
+  box-shadow: var(--elevation-1);
+  transition: transform var(--duration-fast) var(--easing-standard);
+}
+
+.gallery-item:hover {
+  transform: translateY(-2px);
+}
+
+.gallery-item:active {
+  transform: translateY(0);
+}
+
+.gallery-item-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gallery-item-badge {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-2);
+  font: var(--font-caption);
+  font-weight: 500;
+}
+
+.gallery-item-selected {
+  outline: 3px solid var(--color-primary);
+}
+
+/* Detail View */
+.detail-view {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-medium) var(--easing-standard);
+}
+
+.detail-view.is-open {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.detail-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+}
+
+.detail-image {
+  max-width: 90vw;
+  max-height: 80vh;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--elevation-4);
+}
+
+.detail-actions {
+  position: absolute;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  display: flex;
+  gap: var(--space-3);
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-full);
+  padding: var(--space-2);
+  box-shadow: var(--elevation-3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-medium) var(--easing-decelerate),
+              transform var(--duration-medium) var(--easing-decelerate);
+}
+
+.detail-toggle {
+  gap: var(--space-2);
+}
+
+.detail-toggle.is-active {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.detail-toggle.is-active:hover {
+  background-color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+/* Show actions only when detail view is open */
+.detail-view.is-open .detail-actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+.detail-close-btn {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 101;
+  background-color: rgba(0,0,0,0.3);
+  color: white;
+}
+
+.detail-close-btn:hover {
+    background-color: rgba(0,0,0,0.5);
+}
+
+/* Export Screen */
+.export-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--duration-medium) var(--easing-decelerate),
+              transform var(--duration-medium) var(--easing-decelerate);
+}
+
+/* Visible state for screens */
+.capture-screen.is-active,
+.gallery-screen.is-active,
+.export-screen.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.export-content {
+  flex: 1;
+  padding: var(--space-4);
+  overflow-y: auto;
+}
+
+.export-section {
+  margin-bottom: var(--space-5);
+}
+
+.export-section-title {
+  font: var(--font-section);
+  color: var(--color-text);
+  margin-bottom: var(--space-3);
+}
+
+.export-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.size-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.size-segmented {
+  width: 100%;
+}
+
+.metadata-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.metadata-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+}
+
+.export-actions {
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+.export-button {
+  width: 100%;
+}
+
+/* Navigation */
+.navigation {
+  display: flex;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+.nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-1);
+  gap: var(--space-1);
+  color: var(--color-text-secondary);
+  font: var(--font-caption);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--easing-standard);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav-item:hover {
+  color: var(--color-text);
+}
+
+.nav-item.is-active {
+  color: var(--color-primary);
+}
+
+.nav-icon {
+  font-size: var(--size-icon-lg);
+}
+
+/* Loading States */
+.is-loading {
+  position: relative;
+  pointer-events: none;
+}
+
+.is-loading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1;
+}
+
+.is-loading::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 24px;
+  height: 24px;
+  border: 3px solid var(--color-bg-tertiary);
+  border-top: 3px solid var(--color-primary);
+  border-radius: var(--radius-full);
+  animation: spin-centered 1s linear infinite;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
+/* Error States */
+.error-message {
+  padding: var(--space-3);
+  background: rgba(244, 67, 54, 0.1);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  font: var(--font-body-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.error-message .icon {
+  flex-shrink: 0;
+}
+
+.error-action {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font: var(--font-button);
+  cursor: pointer;
+  padding: 0;
+  margin-left: var(--space-1);
+}
+
+.error-action:hover {
+  text-decoration: underline;
+}
+
+/* Animations */
+@keyframes spin-centered {
+  0% { transform: translate(-50%, -50%) rotate(0deg); }
+  100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* Responsive */
+@media (min-width: 768px) {
+  .gallery-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  
+  .detail-content {
+    padding: var(--space-6);
+  }
+}
+
+@media (min-width: 1024px) {
+  .gallery-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  
+  .mode-chips {
+    justify-content: center;
+  }
+}
+
+/* Reduce Motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  
+  .gallery-item:hover {
+    transform: none;
+  }
+  
+  .shutter-button:hover {
+    transform: none;
+  }
+}

--- a/static/theme.css
+++ b/static/theme.css
@@ -1,13 +1,15 @@
-/* Dark theme is the default; light palette is opt‑in */
+/* Revised design tokens and component styles */
 :root {
   /* Color palette */
-  --color-bg: #0d0d0d;
-  --color-surface: #1a1a1a;
-  --color-text: #e6e6e6;
-  --color-primary: #1e40af;
-  --color-on-primary: #ffffff;
-  --color-border: #2a2a2a;
-  --color-danger: #ff4d4f;
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-alt: #242424;
+  --color-text: #fafafa;
+  --color-subtle: #b3b3b3;
+  --color-primary: #ff6b2c;
+  --color-on-primary: #000000;
+  --color-border: #2c2c2c;
+  --color-danger: #ff5b5b;
 
   /* Radii */
   --radius-sm: 4px;
@@ -23,27 +25,31 @@
   --space-5: 32px;
   --space-6: 40px;
 
-  /* Type scale */
-  --font-title: 700 24px/32px 'Space Mono', 'Google Sans Display', sans-serif;
-  --font-section: 600 20px/28px 'Space Mono', 'Google Sans Display', sans-serif;
-  --font-body: 400 16px/24px 'Space Mono', 'Google Sans Display', sans-serif;
-  --font-caption: 400 14px/20px 'Space Mono', 'Google Sans Display', sans-serif;
+  /* Typography */
+  --font-title: 600 28px/36px 'Inter', sans-serif;
+  --font-section: 500 20px/28px 'Inter', sans-serif;
+  --font-body: 400 16px/24px 'Inter', sans-serif;
+  --font-caption: 400 14px/20px 'Inter', sans-serif;
 
   /* Elevation */
-  --elevation-1: 0 1px 2px rgba(0,0,0,0.6);
-  --elevation-2: 0 2px 4px rgba(0,0,0,0.7);
+  --elevation-1: 0 1px 2px rgba(0,0,0,0.7);
+  --elevation-2: 0 2px 4px rgba(0,0,0,0.75);
   --elevation-3: 0 4px 8px rgba(0,0,0,0.8);
 
-  transition: background-color .2s, color .2s;
+  transition: background-color .15s, color .15s;
 }
 
+/* Light theme tokens */
 [data-theme='light'] {
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f5;
+  --color-bg: #f7f7f7;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f0f0;
   --color-text: #111111;
-  --color-primary: #0066ff;
+  --color-subtle: #555555;
+  --color-primary: #ff6b2c;
   --color-on-primary: #ffffff;
-  --color-border: #d0d0d0;
+  --color-border: #d9d9d9;
+  --color-danger: #d0011b;
 }
 
 body {
@@ -57,16 +63,19 @@ h2 { font: var(--font-section); }
 p { font: var(--font-body); }
 .caption { font: var(--font-caption); }
 
-/* Components */
+/* Buttons */
 .button {
   min-height: 44px;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  background: var(--color-surface);
+  background: var(--color-surface-alt);
   color: var(--color-text);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   box-shadow: var(--elevation-1);
-  transition: background-color .2s, box-shadow .2s, transform .2s;
+  transition: background .15s, color .15s, box-shadow .15s, transform .15s;
 }
 .button:hover {
   background: var(--color-primary);
@@ -77,7 +86,7 @@ p { font: var(--font-body); }
   box-shadow: var(--elevation-2);
 }
 .button[disabled] {
-  opacity: 0.38;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 .button--primary {
@@ -86,13 +95,14 @@ p { font: var(--font-body); }
   border-color: var(--color-primary);
 }
 
+/* Chips */
 .chip {
   display: inline-flex;
   align-items: center;
   padding: 0 var(--space-2);
   min-height: 32px;
   border-radius: var(--radius-lg);
-  background: var(--color-surface);
+  background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   font: var(--font-caption);
 }
@@ -101,12 +111,12 @@ p { font: var(--font-body); }
   color: var(--color-on-primary);
 }
 
+/* Slider */
 .slider {
   width: 100%;
   height: 4px;
   border-radius: var(--radius-sm);
   background: var(--color-border);
-  outline: none;
 }
 .slider::-webkit-slider-thumb {
   width: 20px;
@@ -123,6 +133,7 @@ p { font: var(--font-body); }
   cursor: pointer;
 }
 
+/* Toast */
 .toast {
   position: fixed;
   bottom: var(--space-3);
@@ -137,6 +148,7 @@ p { font: var(--font-body); }
 }
 .toast.is-visible { display: block; }
 
+/* Bottom sheet */
 .bottom-sheet {
   position: fixed;
   left: 0;
@@ -152,6 +164,7 @@ p { font: var(--font-body); }
 }
 .bottom-sheet.is-open { transform: translateY(0); }
 
+/* Progress HUD */
 .progress-hud {
   position: fixed;
   inset: 0;
@@ -165,5 +178,5 @@ p { font: var(--font-body); }
 .progress-hud.is-visible { display: flex; }
 
 @media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; animation-duration: 0s !important; }
+  * { transition: none !important; animation: none !important; }
 }

--- a/static/theme.css
+++ b/static/theme.css
@@ -1,0 +1,168 @@
+:root {
+  /* Color palette */
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-text: #111111;
+  --color-primary: #0066ff;
+  --color-on-primary: #ffffff;
+  --color-border: #d0d0d0;
+  --color-danger: #d32f2f;
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+
+  /* Spacing scale (8pt) */
+  --space-0: 0px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  --space-6: 40px;
+
+  /* Type scale */
+  --font-title: 700 24px/32px 'Space Mono', 'Google Sans Display', sans-serif;
+  --font-section: 600 20px/28px 'Space Mono', 'Google Sans Display', sans-serif;
+  --font-body: 400 16px/24px 'Space Mono', 'Google Sans Display', sans-serif;
+  --font-caption: 400 14px/20px 'Space Mono', 'Google Sans Display', sans-serif;
+
+  /* Elevation */
+  --elevation-1: 0 1px 2px rgba(0,0,0,0.1);
+  --elevation-2: 0 2px 4px rgba(0,0,0,0.15);
+  --elevation-3: 0 4px 8px rgba(0,0,0,0.2);
+
+  transition: background-color .2s, color .2s;
+}
+
+[data-theme='dark'] {
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-text: #ffffff;
+  --color-primary: #4e9eff;
+  --color-on-primary: #000000;
+  --color-border: #333333;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: var(--font-body);
+}
+
+h1 { font: var(--font-title); }
+h2 { font: var(--font-section); }
+p { font: var(--font-body); }
+.caption { font: var(--font-caption); }
+
+/* Components */
+.button {
+  min-height: 44px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--elevation-1);
+  transition: background-color .2s, box-shadow .2s, transform .2s;
+}
+.button:hover {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+.button:active {
+  transform: scale(0.97);
+  box-shadow: var(--elevation-2);
+}
+.button[disabled] {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+.button--primary {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border-color: var(--color-primary);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  min-height: 32px;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  font: var(--font-caption);
+}
+.chip--selected {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.slider {
+  width: 100%;
+  height: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+  outline: none;
+}
+.slider::-webkit-slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+}
+.slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+}
+
+.toast {
+  position: fixed;
+  bottom: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-2);
+  display: none;
+}
+.toast.is-visible { display: block; }
+
+.bottom-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--color-surface);
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
+  box-shadow: var(--elevation-3);
+  padding: var(--space-3);
+  transform: translateY(100%);
+  transition: transform .2s;
+}
+.bottom-sheet.is-open { transform: translateY(0); }
+
+.progress-hud {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.5);
+  color: var(--color-on-primary);
+  font: var(--font-body);
+}
+.progress-hud.is-visible { display: flex; }
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation-duration: 0s !important; }
+}

--- a/static/theme.css
+++ b/static/theme.css
@@ -1,12 +1,13 @@
+/* Dark theme is the default; light palette is opt‑in */
 :root {
   /* Color palette */
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f5;
-  --color-text: #111111;
-  --color-primary: #0066ff;
+  --color-bg: #0d0d0d;
+  --color-surface: #1a1a1a;
+  --color-text: #e6e6e6;
+  --color-primary: #1e40af;
   --color-on-primary: #ffffff;
-  --color-border: #d0d0d0;
-  --color-danger: #d32f2f;
+  --color-border: #2a2a2a;
+  --color-danger: #ff4d4f;
 
   /* Radii */
   --radius-sm: 4px;
@@ -29,20 +30,20 @@
   --font-caption: 400 14px/20px 'Space Mono', 'Google Sans Display', sans-serif;
 
   /* Elevation */
-  --elevation-1: 0 1px 2px rgba(0,0,0,0.1);
-  --elevation-2: 0 2px 4px rgba(0,0,0,0.15);
-  --elevation-3: 0 4px 8px rgba(0,0,0,0.2);
+  --elevation-1: 0 1px 2px rgba(0,0,0,0.6);
+  --elevation-2: 0 2px 4px rgba(0,0,0,0.7);
+  --elevation-3: 0 4px 8px rgba(0,0,0,0.8);
 
   transition: background-color .2s, color .2s;
 }
 
-[data-theme='dark'] {
-  --color-bg: #121212;
-  --color-surface: #1e1e1e;
-  --color-text: #ffffff;
-  --color-primary: #4e9eff;
-  --color-on-primary: #000000;
-  --color-border: #333333;
+[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-text: #111111;
+  --color-primary: #0066ff;
+  --color-on-primary: #ffffff;
+  --color-border: #d0d0d0;
 }
 
 body {

--- a/static/theme.css
+++ b/static/theme.css
@@ -1,22 +1,39 @@
-/* Revised design tokens and component styles */
+/* Design Tokens and Component Styles for GemBooth UI Overhaul */
+
 :root {
-  /* Color palette */
-  --color-bg: #121212;
-  --color-surface: #1e1e1e;
-  --color-surface-alt: #242424;
-  --color-text: #fafafa;
-  --color-subtle: #b3b3b3;
-  --color-primary: #ff6b2c;
-  --color-on-primary: #000000;
-  --color-border: #2c2c2c;
-  --color-danger: #ff5b5b;
+  /* Color palette - Dark Theme (Default) */
+  --color-bg: #121212;              /* Primary background */
+  --color-bg-secondary: #1e1e1e;    /* Secondary background */
+  --color-bg-tertiary: #242424;     /* Tertiary background */
+  --color-surface: #1e1e1e;         /* Cards, sheets, menus */
+  --color-surface-alt: #242424;     /* Alternate surfaces */
+  --color-text: #ffffff;            /* Primary text */
+  --color-text-secondary: #b3b3b3;  /* Secondary text */
+  --color-text-tertiary: #888888;   /* Tertiary text */
+  --color-text-inverse: #121212;    /* Inverse text */
+  --color-primary: #ff6b2c;         /* Primary brand color */
+  --color-primary-hover: #ff7c42;   /* Primary hover state */
+  --color-primary-pressed: #e05a20; /* Primary pressed state */
+  --color-primary-disabled: #ff6b2c80; /* Primary disabled state */
+  --color-on-primary: #ffffff;      /* Text on primary */
+  --color-border: #2c2c2c;          /* Borders and dividers */
+  --color-border-strong: #444444;   /* Strong borders */
+  --color-success: #4caf50;         /* Success states */
+  --color-warning: #ff9800;         /* Warning states */
+  --color-danger: #f44336;          /* Danger/error states */
+  --color-danger-hover: #f55549;    /* Danger hover state */
+  --color-danger-pressed: #d32f2f;  /* Danger pressed state */
+  --color-focus: #ff6b2c;           /* Focus indicators */
 
   /* Radii */
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 16px;
+  --radius-xs: 2px;                 /* Extra small radius */
+  --radius-sm: 4px;                 /* Small radius */
+  --radius-md: 8px;                 /* Medium radius */
+  --radius-lg: 12px;                /* Large radius */
+  --radius-xl: 16px;                /* Extra large radius */
+  --radius-full: 50%;               /* Circular radius */
 
-  /* Spacing scale (8pt) */
+  /* Spacing scale (8pt grid) */
   --space-0: 0px;
   --space-1: 4px;
   --space-2: 8px;
@@ -24,159 +41,852 @@
   --space-4: 24px;
   --space-5: 32px;
   --space-6: 40px;
+  --space-7: 48px;
+  --space-8: 56px;
+  --space-9: 64px;
 
   /* Typography */
-  --font-title: 600 28px/36px 'Inter', sans-serif;
-  --font-section: 500 20px/28px 'Inter', sans-serif;
-  --font-body: 400 16px/24px 'Inter', sans-serif;
-  --font-caption: 400 14px/20px 'Inter', sans-serif;
+  --font-display: 700 32px/40px 'Inter', sans-serif;    /* Display headings */
+  --font-title: 600 24px/32px 'Inter', sans-serif;     /* Page titles */
+  --font-section: 500 20px/28px 'Inter', sans-serif;   /* Section headings */
+  --font-body-lg: 400 18px/26px 'Inter', sans-serif;   /* Large body text */
+  --font-body: 400 16px/24px 'Inter', sans-serif;      /* Default body text */
+  --font-body-sm: 400 14px/20px 'Inter', sans-serif;   /* Small body text */
+  --font-caption: 400 12px/16px 'Inter', sans-serif;   /* Captions, labels */
+  --font-button: 500 16px/24px 'Inter', sans-serif;    /* Button text */
 
   /* Elevation */
-  --elevation-1: 0 1px 2px rgba(0,0,0,0.7);
-  --elevation-2: 0 2px 4px rgba(0,0,0,0.75);
-  --elevation-3: 0 4px 8px rgba(0,0,0,0.8);
+  --elevation-1: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  --elevation-2: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  --elevation-3: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+  --elevation-4: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
+  --elevation-5: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
 
-  transition: background-color .15s, color .15s;
+  /* Animation */
+  --duration-fast: 150ms;
+  --duration-medium: 250ms;
+  --duration-slow: 350ms;
+  --easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --easing-accelerate: cubic-bezier(0.4, 0, 1, 1);
+  --easing-decelerate: cubic-bezier(0, 0, 0.2, 1);
+
+  /* Focus */
+  --focus-ring: 0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-focus);
+
+  /* Sizes */
+  --size-tap-target: 44px;          /* Minimum tap target size */
+  --size-icon-sm: 16px;             /* Small icons */
+  --size-icon-md: 24px;             /* Medium icons */
+  --size-icon-lg: 32px;             /* Large icons */
+  --size-shutter: 72px;             /* Camera shutter */
+  --size-avatar: 40px;              /* Avatar size */
+  --size-thumbnail: 80px;           /* Thumbnail size */
 }
 
-/* Light theme tokens */
+/* Light Theme Tokens */
 [data-theme='light'] {
-  --color-bg: #f7f7f7;
+  --color-bg: #ffffff;
+  --color-bg-secondary: #f7f7f7;
+  --color-bg-tertiary: #eeeeee;
   --color-surface: #ffffff;
   --color-surface-alt: #f0f0f0;
   --color-text: #111111;
-  --color-subtle: #555555;
+  --color-text-secondary: #555555;
+  --color-text-tertiary: #888888;
+  --color-text-inverse: #ffffff;
   --color-primary: #ff6b2c;
+  --color-primary-hover: #ff7c42;
+  --color-primary-pressed: #e05a20;
+  --color-primary-disabled: #ff6b2c80;
   --color-on-primary: #ffffff;
   --color-border: #d9d9d9;
-  --color-danger: #d0011b;
+  --color-border-strong: #aaaaaa;
+  --color-success: #4caf50;
+  --color-warning: #ff9800;
+  --color-danger: #f44336;
+  --color-danger-hover: #f55549;
+  --color-danger-pressed: #d32f2f;
+  --color-focus: #ff6b2c;
+}
+
+/* Global Styles */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  touch-action: manipulation;
 }
 
 body {
   background: var(--color-bg);
   color: var(--color-text);
   font: var(--font-body);
+  font-feature-settings: "liga" 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-h1 { font: var(--font-title); }
-h2 { font: var(--font-section); }
-p { font: var(--font-body); }
-.caption { font: var(--font-caption); }
-
-/* Buttons */
-.button {
-  min-height: 44px;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  color: var(--color-text);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  box-shadow: var(--elevation-1);
-  transition: background .15s, color .15s, box-shadow .15s, transform .15s;
-}
-.button:hover {
+/* Selection */
+::selection {
   background: var(--color-primary);
   color: var(--color-on-primary);
 }
+
+/* Focus Visible */
+*:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+/* Links */
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Lists */
+ul,
+ol {
+  list-style: none;
+}
+
+/* Images */
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+/* Icon Font (Material Symbols) */
+.icon,
+.toast-icon {
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: var(--size-icon-md);
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 24;
+}
+
+/* Larger nav icons */
+.nav-icon {
+  font-size: var(--size-icon-lg);
+}
+
+/* Buttons */
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--size-tap-target);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  font: var(--font-button);
+  text-align: center;
+  cursor: pointer;
+  transition: 
+    background-color var(--duration-fast) var(--easing-standard),
+    color var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard),
+    box-shadow var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.button:hover {
+  background: var(--color-bg-tertiary);
+  transform: translateY(-1px);
+  box-shadow: var(--elevation-1);
+}
+
 .button:active {
   transform: scale(0.97);
-  box-shadow: var(--elevation-2);
 }
-.button[disabled] {
+
+.button:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+
+.button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  transform: none;
 }
+
+/* Primary Button */
 .button--primary {
   background: var(--color-primary);
   color: var(--color-on-primary);
   border-color: var(--color-primary);
+  box-shadow: var(--elevation-1);
+}
+
+.button--primary:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+  box-shadow: var(--elevation-2);
+  transform: translateY(-2px);
+}
+
+.button--primary:active {
+  background: var(--color-primary-pressed);
+  border-color: var(--color-primary-pressed);
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.button--primary:disabled {
+  background: var(--color-primary-disabled);
+  border-color: var(--color-primary-disabled);
+  box-shadow: none;
+}
+
+/* Secondary Button */
+.button--secondary {
+  background: transparent;
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
+}
+
+.button--secondary:hover {
+  background: var(--color-bg-secondary);
+}
+
+.button--secondary:active {
+  background: var(--color-bg-tertiary);
+}
+
+/* Danger Button */
+.button--danger {
+  background: var(--color-danger);
+  color: var(--color-on-primary);
+  border-color: var(--color-danger);
+}
+
+.button--danger:hover {
+  background: var(--color-danger-hover);
+  border-color: var(--color-danger-hover);
+}
+
+.button--danger:active {
+  background: var(--color-danger-pressed);
+  border-color: var(--color-danger-pressed);
+}
+
+/* Icon Button */
+.button--icon {
+  min-width: var(--size-tap-target);
+  min-height: var(--size-tap-target);
+  padding: var(--space-2);
+  border-radius: var(--radius-full);
+  background-color: var(--color-surface-alt);
+  transition: background-color var(--duration-fast) var(--easing-standard);
+}
+
+.button--icon:hover {
+    background-color: var(--color-bg-tertiary);
+}
+
+.button--icon-sm {
+  min-width: 36px;
+  min-height: 36px;
+  padding: var(--space-1);
 }
 
 /* Chips */
 .chip {
   display: inline-flex;
   align-items: center;
-  padding: 0 var(--space-2);
-  min-height: 32px;
-  border-radius: var(--radius-lg);
+  padding: 0 var(--space-3);
+  min-height: 36px;
+  border-radius: var(--radius-md);
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
-  font: var(--font-caption);
+  color: var(--color-text);
+  font: var(--font-body-sm);
+  cursor: pointer;
+  transition: 
+    background-color var(--duration-fast) var(--easing-standard),
+    color var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
+
+.chip:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.chip:active {
+  transform: scale(0.97);
+}
+
+.chip:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+
 .chip--selected {
   background: var(--color-primary);
   color: var(--color-on-primary);
+  border-color: var(--color-primary);
+  box-shadow: 0 8px 18px rgba(255, 107, 44, 0.25);
+}
+
+.chip--selected:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.chip--selected:active {
+  background: var(--color-primary-pressed);
+  border-color: var(--color-primary-pressed);
+}
+
+/* Icon in Chips */
+.chip .icon {
+  margin-right: var(--space-1);
 }
 
 /* Slider */
+.slider-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.slider-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font: var(--font-caption);
+  color: var(--color-text-secondary);
+}
+
+.slider-label-value {
+  font-weight: 500;
+}
+
 .slider {
   width: 100%;
-  height: 4px;
+  height: 6px;
   border-radius: var(--radius-sm);
-  background: var(--color-border);
+  background: var(--color-bg-tertiary);
+  outline: none;
+  -webkit-appearance: none;
 }
+
 .slider::-webkit-slider-thumb {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-primary);
   cursor: pointer;
+  -webkit-appearance: none;
+  border: 2px solid var(--color-on-primary);
+  box-shadow: var(--elevation-1);
 }
+
 .slider::-moz-range-thumb {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-primary);
   cursor: pointer;
+  border: 2px solid var(--color-on-primary);
+  box-shadow: var(--elevation-1);
+}
+
+.slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: var(--focus-ring);
+}
+
+.slider:focus-visible::-moz-range-thumb {
+  box-shadow: var(--focus-ring);
+}
+
+/* Toggle */
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 28px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--color-bg-tertiary);
+  transition: var(--duration-fast) var(--easing-standard);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  bottom: 3px;
+  background-color: var(--color-text-secondary);
+  transition: var(--duration-fast) var(--easing-standard);
+  border-radius: var(--radius-full);
+}
+
+.toggle input:checked + .toggle-slider {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.toggle input:checked + .toggle-slider:before {
+  background-color: var(--color-on-primary);
+  transform: translateX(22px);
+}
+
+.toggle:focus-visible input + .toggle-slider {
+  box-shadow: var(--focus-ring);
 }
 
 /* Toast */
 .toast {
   position: fixed;
-  bottom: var(--space-3);
+  bottom: var(--space-5);
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateY(20px);
+  opacity: 0;
+  visibility: hidden;
   background: var(--color-surface);
   color: var(--color-text);
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
-  box-shadow: var(--elevation-2);
-  display: none;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--elevation-3);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 280px;
+  max-width: 90vw;
+  z-index: 1000;
+  transition: transform var(--duration-medium) var(--easing-decelerate),
+              opacity var(--duration-medium) var(--easing-decelerate),
+              visibility 0s var(--duration-medium);
+  pointer-events: none;
 }
-.toast.is-visible { display: block; }
 
-/* Bottom sheet */
+.toast.is-visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
+  pointer-events: auto;
+}
+
+.toast--success {
+  border-left: 4px solid var(--color-success);
+}
+
+.toast--error {
+  border-left: 4px solid var(--color-danger);
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  width: var(--size-icon-md);
+  height: var(--size-icon-md);
+}
+
+.toast-content {
+  flex: 1;
+  font: var(--font-body-sm);
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toast-close:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+
+/* Bottom Sheet */
 .bottom-sheet {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
   background: var(--color-surface);
-  border-top-left-radius: var(--radius-lg);
-  border-top-right-radius: var(--radius-lg);
-  box-shadow: var(--elevation-3);
-  padding: var(--space-3);
+  border-top-left-radius: var(--radius-xl);
+  border-top-right-radius: var(--radius-xl);
+  box-shadow: var(--elevation-4);
+  padding: var(--space-4);
   transform: translateY(100%);
-  transition: transform .2s;
+  transition: transform var(--duration-medium) var(--easing-decelerate);
+  max-height: 80vh;
+  overflow-y: auto;
+  z-index: 900;
 }
-.bottom-sheet.is-open { transform: translateY(0); }
+
+.bottom-sheet.is-open {
+  transform: translateY(0);
+}
+
+.bottom-sheet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.bottom-sheet-title {
+  font: var(--font-section);
+  color: var(--color-text);
+}
+
+.bottom-sheet-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bottom-sheet-close:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
 
 /* Progress HUD */
 .progress-hud {
   position: fixed;
   inset: 0;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0,0,0,0.5);
-  color: var(--color-on-primary);
-  font: var(--font-body);
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-medium) var(--easing-standard);
 }
-.progress-hud.is-visible { display: flex; }
 
+.progress-hud.is-visible {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.progress-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  min-width: 280px;
+  box-shadow: var(--elevation-3);
+  display: grid;
+  justify-items: center;
+}
+
+.progress-spinner {
+  width: 48px;
+  height: 48px;
+  position: relative;
+  margin-bottom: var(--space-3);
+}
+
+.progress-spinner::after {
+  content: "";
+  display: block;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid var(--color-bg-tertiary);
+  border-top-color: var(--color-primary);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.progress-text {
+  font: var(--font-body);
+  color: var(--color-text);
+  margin-bottom: var(--space-2);
+}
+
+.progress-subtext {
+  font: var(--font-caption);
+  color: var(--color-text-secondary);
+}
+
+.progress-cancel {
+  margin-top: var(--space-3);
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font: var(--font-button);
+  cursor: pointer;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+}
+
+.progress-cancel:hover {
+  text-decoration: underline;
+}
+
+/* Segmented Control */
+.segmented-control {
+  display: inline-flex;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-md);
+  padding: var(--space-1);
+}
+
+.segmented-control-item {
+  position: relative;
+  z-index: 1;
+}
+
+.segmented-control-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.segmented-control-label {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  font: var(--font-button);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--easing-standard);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.segmented-control-input:checked + .segmented-control-label {
+  color: var(--color-on-primary);
+}
+
+.segmented-control-indicator {
+  position: absolute;
+  top: var(--space-1);
+  bottom: var(--space-1);
+  left: 0;
+  background: var(--color-primary);
+  border-radius: var(--radius-sm);
+  transition: transform var(--duration-fast) var(--easing-standard);
+  z-index: 0;
+}
+
+/* Grid */
+.grid {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.grid-cols-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.grid-cols-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+/* Aspect Ratio */
+.aspect-square {
+  aspect-ratio: 1 / 1;
+}
+
+.aspect-video {
+  aspect-ratio: 16 / 9;
+}
+
+/* Utilities */
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-1 { gap: var(--space-1); }
+.gap-2 { gap: var(--space-2); }
+.gap-3 { gap: var(--space-3); }
+.gap-4 { gap: var(--space-4); }
+
+.m-0 { margin: 0; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.my-2 { margin-top: var(--space-2); margin-bottom: var(--space-2); }
+.my-3 { margin-top: var(--space-3); margin-bottom: var(--space-3); }
+.my-4 { margin-top: var(--space-4); margin-bottom: var(--space-4); }
+.mt-2 { margin-top: var(--space-2); }
+.mt-3 { margin-top: var(--space-3); }
+.mt-4 { margin-top: var(--space-4); }
+.mb-2 { margin-bottom: var(--space-2); }
+.mb-3 { margin-bottom: var(--space-3); }
+.mb-4 { margin-bottom: var(--space-4); }
+
+.p-0 { padding: 0; }
+.p-2 { padding: var(--space-2); }
+.p-3 { padding: var(--space-3); }
+.p-4 { padding: var(--space-4); }
+.px-2 { padding-left: var(--space-2); padding-right: var(--space-2); }
+.px-3 { padding-left: var(--space-3); padding-right: var(--space-3); }
+.px-4 { padding-left: var(--space-4); padding-right: var(--space-4); }
+.py-2 { padding-top: var(--space-2); padding-bottom: var(--space-2); }
+.py-3 { padding-top: var(--space-3); padding-bottom: var(--space-3); }
+.py-4 { padding-top: var(--space-4); padding-bottom: var(--space-4); }
+
+.w-full { width: 100%; }
+.h-full { height: 100%; }
+
+.rounded-full { border-radius: var(--radius-full); }
+
+.bg-surface { background: var(--color-surface); }
+.bg-surface-alt { background: var(--color-surface-alt); }
+
+.text-primary { color: var(--color-primary); }
+.text-secondary { color: var(--color-text-secondary); }
+.text-danger { color: var(--color-danger); }
+
+.font-title { font: var(--font-title); }
+.font-section { font: var(--font-section); }
+.font-body { font: var(--font-body); }
+.font-caption { font: var(--font-caption); }
+
+/* Animation Utilities */
+.animate-fade-in {
+  animation: fadeIn var(--duration-medium) var(--easing-standard);
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.animate-scale-in {
+  animation: scaleIn var(--duration-medium) var(--easing-decelerate);
+}
+
+@keyframes scaleIn {
+  from { 
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to { 
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Reduce Motion */
 @media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; animation: none !important; }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  
+  .toast {
+    transition: none;
+  }
+  
+  .bottom-sheet {
+    transition: none;
+  }
+  
+  .progress-hud {
+    transition: none;
+  }
+  
+  .segmented-control-indicator {
+    transition: none;
+  }
+}
+
+/* Print Styles */
+@media print {
+  .button,
+  .chip,
+  .toast,
+  .bottom-sheet,
+  .progress-hud {
+    display: none !important;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gembooth</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
@@ -12,309 +12,641 @@
 </head>
 <body>
     <main class="app">
-        <section class="preview">
-            <video id="video" autoplay playsinline></video>
-            <img id="upload-preview" alt="Preview" style="display:none; max-width:100%; max-height:100%; object-fit:contain;" />
-            <canvas id="canvas" style="display:none;"></canvas>
-            <div class="source-controls">
-              <button id="toggle-source" class="button" title="Switch source" aria-label="Switch source">
-                <span class="icon">switch_camera</span><span id="source-label">Camera</span>
-              </button>
-              <label class="button" for="file-input" id="upload-label" aria-label="Import photo" style="display:none;">
-                <span class="icon">upload</span>Import
-              </label>
-              <input id="file-input" type="file" accept="image/*" style="display:none;" />
+        <!-- Capture Screen -->
+        <div class="capture-screen" id="capture-screen">
+            <div class="preview-container">
+                <video id="video" class="preview-video" autoplay playsinline></video>
+                <img id="upload-preview" class="preview-image" alt="Preview" />
+                <canvas id="canvas" style="display:none;"></canvas>
+                <div class="preview-overlay"></div>
             </div>
-            <button id="snap" class="shutter" aria-label="Take photo">
-                <span class="icon">photo_camera</span>
-            </button>
-        </section>
-        <section class="controls">
-            <select id="mode" aria-label="Style">
+            
+            <div class="capture-actions">
+                <button id="toggle-source" class="button button--icon" title="Switch source" aria-label="Switch source">
+                    <span class="icon">switch_camera</span>
+                </button>
+                <label class="button button--icon" for="file-input" id="upload-label" aria-label="Import photo" style="display:none;">
+                    <span class="icon">upload</span>
+                </label>
+                <input id="file-input" type="file" accept="image/*" style="display:none;" />
+            </div>
+            
+            <div class="capture-controls">
+                <button id="snap" class="shutter-button" aria-label="Take photo">
+                    <span class="icon">photo_camera</span>
+                </button>
+            </div>
+        </div>
+        
+        <!-- Mode Selection -->
+        <div class="mode-selection">
+            <div class="mode-header">
+                <h2 class="mode-title">Styles</h2>
+                <button id="custom-toggle" class="mode-toggle">
+                    <span class="icon">edit</span>
+                    Custom
+                </button>
+            </div>
+            
+            <div class="mode-chips" id="mode-chips">
                 {% for key, value in modes.items() %}
-                    <option value="{{ key }}">{{ value.emoji }} {{ value.name }}</option>
+                    <div class="chip mode-chip" data-mode="{{ key }}">
+                        <span class="icon">{{ value.emoji }}</span>
+                        {{ value.name }}
+                    </div>
                 {% endfor %}
-                <option value="custom">✏️ Custom</option>
-            </select>
-            <textarea id="custom-prompt" placeholder="Describe your style" aria-label="Custom prompt" style="display:none;"></textarea>
-        </section>
-        <section class="gallery">
-            <ul id="photo-gallery"><li id="empty-state" class="empty">Let’s make something. Take a photo or import one.</li></ul>
-        </section>
-        <section class="export">
-            <button id="make-gif" class="button button--primary">Create GIF</button>
-            <div id="gif-result"></div>
-        </section>
+                <div class="chip mode-chip" data-mode="custom">
+                    <span class="icon">edit</span>
+                    Custom
+                </div>
+            </div>
+            
+            <div class="custom-prompt-container" id="custom-prompt-container">
+                <textarea id="custom-prompt" class="custom-prompt-textarea" placeholder="Describe your style..." aria-label="Custom prompt"></textarea>
+            </div>
+        </div>
+        
+        <!-- Gallery Screen -->
+        <div class="gallery-screen" id="gallery-screen" style="display: none;">
+            <div class="gallery-header">
+                <h2 class="gallery-title">Gallery</h2>
+                <div class="gallery-actions">
+                    <button id="select-mode-btn" class="button button--icon" aria-label="Select photos">
+                        <span class="icon">select</span>
+                    </button>
+                    <button id="create-gif-btn" class="button button--primary" style="display: none;">
+                        <span class="icon">movie</span>
+                        Create GIF
+                    </button>
+                </div>
+            </div>
+            
+            <div class="gallery-content">
+                <ul id="photo-gallery" class="gallery-grid">
+                    <li class="gallery-empty" id="empty-state">
+                        <span class="icon">photo_library</span>
+                        <p class="gallery-empty-text">Let's make something. Take a photo or import one.</p>
+                        <button id="back-to-capture" class="button button--primary">Go to Camera</button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        
+        <!-- Export Screen -->
+        <div class="export-screen" id="export-screen" style="display: none;">
+            <div class="gallery-header">
+                <h2 class="gallery-title">Export</h2>
+            </div>
+            
+            <div class="export-content">
+                <div class="export-section">
+                    <h3 class="export-section-title">Size</h3>
+                    <div class="export-options">
+                        <div class="segmented-control size-segmented">
+                            <div class="segmented-control-item">
+                                <input type="radio" id="size-small" name="size" class="segmented-control-input" checked>
+                                <label for="size-small" class="segmented-control-label">Small</label>
+                            </div>
+                            <div class="segmented-control-item">
+                                <input type="radio" id="size-medium" name="size" class="segmented-control-input">
+                                <label for="size-medium" class="segmented-control-label">Medium</label>
+                            </div>
+                            <div class="segmented-control-item">
+                                <input type="radio" id="size-large" name="size" class="segmented-control-input">
+                                <label for="size-large" class="segmented-control-label">Large</label>
+                            </div>
+                            <div class="segmented-control-indicator"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="export-section">
+                    <h3 class="export-section-title">Metadata</h3>
+                    <div class="export-options">
+                        <div class="metadata-toggle">
+                            <span>Include location data</span>
+                            <div class="toggle">
+                                <input type="checkbox" id="include-location" class="toggle-input">
+                                <span class="toggle-slider"></span>
+                            </div>
+                        </div>
+                        <div class="metadata-toggle">
+                            <span>Include timestamp</span>
+                            <div class="toggle">
+                                <input type="checkbox" id="include-timestamp" class="toggle-input" checked>
+                                <span class="toggle-slider"></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="export-actions">
+                <button id="export-button" class="button button--primary export-button">
+                    <span class="icon">download</span>
+                    Save to Photos
+                </button>
+            </div>
+        </div>
+        
+        <!-- Navigation -->
+        <nav class="navigation">
+            <div class="nav-item is-active" data-screen="capture">
+                <span class="icon nav-icon">photo_camera</span>
+                <span>Capture</span>
+            </div>
+            <div class="nav-item" data-screen="gallery">
+                <span class="icon nav-icon">photo_library</span>
+                <span>Gallery</span>
+            </div>
+            <div class="nav-item" data-screen="export">
+                <span class="icon nav-icon">save</span>
+                <span>Export</span>
+            </div>
+        </nav>
     </main>
-
-    <div id="lightbox" class="lightbox" aria-hidden="true" style="display:none;">
-      <button id="lightbox-close" class="lightbox-close" aria-label="Close"><span class="icon">close</span></button>
-      <img id="lightbox-img" alt="Full view" />
-      <div class="lightbox-actions">
-        <a id="lightbox-download" class="button" href="#" download>
-          <span class="icon">download</span>Download
-        </a>
-      </div>
+    
+    <!-- Detail View -->
+    <div id="detail-view" class="detail-view">
+        <button id="detail-close" class="button button--icon detail-close-btn" aria-label="Close detail view">
+            <span class="icon">close</span>
+        </button>
+        <div class="detail-content">
+            <img id="detail-image" class="detail-image" alt="Detail view" />
+        </div>
+        <div class="detail-actions">
+            <button class="button detail-toggle" id="toggle-original">
+                <span class="icon">photo</span>
+                Original
+            </button>
+            <button class="button detail-toggle" id="toggle-edited">
+                <span class="icon">auto_awesome</span>
+                Edited
+            </button>
+            <button id="detail-download" class="button button--icon">
+                <span class="icon">download</span>
+            </button>
+        </div>
     </div>
-
+    
+    <!-- Toast -->
+    <div id="toast" class="toast">
+        <span id="toast-icon" class="toast-icon"></span>
+        <div id="toast-content" class="toast-content"></div>
+        <button id="toast-close" class="toast-close" aria-label="Close toast"><span class="icon">close</span></button>
+    </div>
+    
+    <!-- Progress HUD -->
+    <div id="progress-hud" class="progress-hud">
+        <div class="progress-content">
+            <div class="progress-spinner"></div>
+            <div id="progress-text" class="progress-text">Applying edit...</div>
+            <div id="progress-percentage" class="progress-subtext">0%</div>
+            <div id="progress-subtext" class="progress-subtext"></div>
+            <button id="progress-cancel" class="progress-cancel">Cancel</button>
+        </div>
+    </div>
+    
     <script>
-        const modesData = JSON.parse(document.getElementById('modes-data').textContent);
-        const video = document.getElementById('video');
-        const canvas = document.getElementById('canvas');
-        const snap = document.getElementById('snap');
-        const photoGallery = document.getElementById('photo-gallery');
-        const modeSelector = document.getElementById('mode');
-        const customPrompt = document.getElementById('custom-prompt');
-        const makeGifButton = document.getElementById('make-gif');
-        const gifResult = document.getElementById('gif-result');
-        const toggleSourceBtn = document.getElementById('toggle-source');
-        const sourceLabel = document.getElementById('source-label');
-        const fileInput = document.getElementById('file-input');
-        const uploadLabel = document.getElementById('upload-label');
-        const uploadPreview = document.getElementById('upload-preview');
+        // App state
+        const state = {
+            currentScreen: 'capture',
+            captureSource: 'camera',
+            selectedMode: 'renaissance',
+            customPrompt: '',
+            photos: [],
+            stream: null,
+            selectedPhotos: [],
+            currentDetailPhoto: null,
+            isDetailOriginal: true,
+            isSelectMode: false,
+        };
+        
+        // DOM Elements
+        const elements = {
+            // Screens
+            captureScreen: document.getElementById('capture-screen'),
+            galleryScreen: document.getElementById('gallery-screen'),
+            exportScreen: document.getElementById('export-screen'),
+            
+            // Video/Preview
+            video: document.getElementById('video'),
+            uploadPreview: document.getElementById('upload-preview'),
+            canvas: document.getElementById('canvas'),
+            
+            // Buttons
+            toggleSourceBtn: document.getElementById('toggle-source'),
+            snapBtn: document.getElementById('snap'),
+            fileInput: document.getElementById('file-input'),
+            uploadLabel: document.getElementById('upload-label'),
+            customToggle: document.getElementById('custom-toggle'),
+            backToCapture: document.getElementById('back-to-capture'),
+            exportButton: document.getElementById('export-button'),
+            selectModeBtn: document.getElementById('select-mode-btn'),
+            createGifBtn: document.getElementById('create-gif-btn'),
+            
+            // Mode Selection
+            modeChips: document.getElementById('mode-chips'),
+            customPromptContainer: document.getElementById('custom-prompt-container'),
+            customPrompt: document.getElementById('custom-prompt'),
+            
+            // Gallery
+            photoGallery: document.getElementById('photo-gallery'),
+            emptyState: document.getElementById('empty-state'),
+            
+            // Detail View
+            detailView: document.getElementById('detail-view'),
+            detailImage: document.getElementById('detail-image'),
+            detailClose: document.getElementById('detail-close'),
+            toggleOriginal: document.getElementById('toggle-original'),
+            toggleEdited: document.getElementById('toggle-edited'),
+            detailDownload: document.getElementById('detail-download'),
+            
+            // Navigation
+            navItems: document.querySelectorAll('.nav-item'),
+            
+            // Toast
+            toast: document.getElementById('toast'),
+            toastIcon: document.getElementById('toast-icon'),
+            toastContent: document.getElementById('toast-content'),
+            
+            // Progress HUD
+            progressHud: document.getElementById('progress-hud'),
+            progressText: document.getElementById('progress-text'),
+            progressSubtext: document.getElementById('progress-subtext'),
+            progressCancel: document.getElementById('progress-cancel')
+        };
+        
+        // Toast timer handle
+        let toastTimer = null;
+        let percentageCounterInterval = null;
 
-        const photos = [];
-        let captureSource = 'camera'; // 'camera' | 'upload'
-        let stream = null;
+        // Initialize the app
+        function init() {
+            updateModeSelection();
+            startCamera();
+            bindEvents();
+            switchScreen('capture');
+        }
+        
+        // Bind event listeners
+        function bindEvents() {
+            elements.navItems.forEach(item => {
+                item.addEventListener('click', () => switchScreen(item.dataset.screen));
+            });
+            
+            elements.toggleSourceBtn.addEventListener('click', toggleSource);
+            elements.snapBtn.addEventListener('click', capturePhoto);
+            elements.fileInput.addEventListener('change', handleFileSelect);
+            
+            elements.modeChips.addEventListener('click', (e) => {
+                const chip = e.target.closest('.mode-chip');
+                if (chip) selectMode(chip.dataset.mode);
+            });
+            
+            elements.customToggle.addEventListener('click', () => selectMode('custom'));
+            elements.customPrompt.addEventListener('input', () => {
+                state.customPrompt = elements.customPrompt.value;
+            });
+            
+            elements.backToCapture.addEventListener('click', () => switchScreen('capture'));
+            elements.selectModeBtn.addEventListener('click', toggleSelectMode);
+            elements.createGifBtn.addEventListener('click', createGif);
+            
+            elements.detailView.addEventListener('click', (e) => {
+                if (e.target === elements.detailView) closeDetailView();
+            });
+            elements.detailClose.addEventListener('click', closeDetailView);
+            
+            elements.toggleOriginal.addEventListener('click', () => {
+                state.isDetailOriginal = true;
+                updateDetailView();
+            });
+            
+            elements.toggleEdited.addEventListener('click', () => {
+                state.isDetailOriginal = false;
+                updateDetailView();
+            });
+            
+            elements.detailDownload.addEventListener('click', downloadDetailImage);
+            
+            elements.toast.addEventListener('click', hideToast);
+            elements.progressCancel.addEventListener('click', hideProgressHud);
 
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    if (elements.detailView.classList.contains('is-open')) closeDetailView();
+                    if (elements.toast.classList.contains('is-visible')) hideToast();
+                }
+            });
+        }
+        
         async function startCamera() {
-          if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) return;
-          try {
-            stream = await navigator.mediaDevices.getUserMedia({ video: true });
-            video.srcObject = stream;
-            await video.play();
-          } catch (e) {
-            captureSource = 'upload';
-            updateSourceUI();
-          }
-        }
-        startCamera();
-
-        function stopCamera() {
-          if (stream) {
-            stream.getTracks().forEach(t => t.stop());
-            stream = null;
-          }
-          video.srcObject = null;
-        }
-
-        function updateSourceUI() {
-          if (captureSource === 'camera') {
-            video.style.display = '';
-            uploadPreview.style.display = 'none';
-            uploadLabel.style.display = 'none';
-            sourceLabel.textContent = 'Camera';
-            if (!stream) startCamera();
-          } else {
-            video.style.display = 'none';
-            uploadPreview.style.display = '';
-            uploadLabel.style.display = '';
-            sourceLabel.textContent = 'Upload';
-            stopCamera();
-          }
-        }
-
-        toggleSourceBtn.addEventListener('click', () => {
-          captureSource = captureSource === 'camera' ? 'upload' : 'camera';
-          updateSourceUI();
-        });
-
-        fileInput.addEventListener('change', (e) => {
-          const files = e && e.target && e.target.files ? e.target.files : null;
-          const file = files && files.length ? files[0] : null;
-          if (!file) return;
-          const reader = new FileReader();
-          reader.onload = (ev) => {
-            uploadPreview.src = ev.target.result;
-          };
-          reader.readAsDataURL(file);
-        });
-        updateSourceUI();
-
-        modeSelector.addEventListener('change', () => {
-            if (modeSelector.value === 'custom') {
-                customPrompt.style.display = 'block';
-            } else {
-                customPrompt.style.display = 'none';
+            if (!navigator.mediaDevices?.getUserMedia) return;
+            try {
+                state.stream = await navigator.mediaDevices.getUserMedia({ video: true });
+                elements.video.srcObject = state.stream;
+                await elements.video.play();
+            } catch (e) {
+                state.captureSource = 'upload';
+                updateSourceUI();
             }
-        });
-
-        snap.addEventListener('click', function() {
+        }
+        
+        function stopCamera() {
+            if (state.stream) {
+                state.stream.getTracks().forEach(track => track.stop());
+                state.stream = null;
+            }
+            elements.video.srcObject = null;
+        }
+        
+        function toggleSource() {
+            state.captureSource = state.captureSource === 'camera' ? 'upload' : 'camera';
+            updateSourceUI();
+        }
+        
+        function updateSourceUI() {
+            const isCamera = state.captureSource === 'camera';
+            elements.video.style.display = isCamera ? '' : 'none';
+            elements.uploadPreview.style.display = isCamera ? 'none' : '';
+            elements.uploadLabel.style.display = isCamera ? 'none' : '';
+            if (isCamera && !state.stream) startCamera();
+            else if (!isCamera) stopCamera();
+        }
+        
+        function handleFileSelect(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = (ev) => elements.uploadPreview.src = ev.target.result;
+            reader.readAsDataURL(file);
+        }
+        
+        function capturePhoto() {
             let dataURL;
-            if (captureSource === 'camera') {
-                if (!video.videoWidth || !video.videoHeight) return;
-                canvas.width = video.videoWidth;
-                canvas.height = video.videoHeight;
-                canvas.getContext('2d').drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
-                dataURL = canvas.toDataURL('image/jpeg');
+            const isCamera = state.captureSource === 'camera';
+            
+            if (isCamera) {
+                if (!elements.video.videoWidth) return;
+                elements.canvas.width = elements.video.videoWidth;
+                elements.canvas.height = elements.video.videoHeight;
+                elements.canvas.getContext('2d').drawImage(elements.video, 0, 0);
+                dataURL = elements.canvas.toDataURL('image/jpeg');
             } else {
-                if (!uploadPreview.src) {
-                    alert('Please choose an image to upload');
+                if (!elements.uploadPreview.src) {
+                    showToast('Please choose an image to upload', 'error');
                     return;
                 }
-                const img = uploadPreview;
-                const w = img.naturalWidth || 512;
-                const h = img.naturalHeight || 512;
-                canvas.width = w;
-                canvas.height = h;
-                canvas.getContext('2d').drawImage(img, 0, 0, w, h);
-                dataURL = canvas.toDataURL('image/jpeg');
+                const img = elements.uploadPreview;
+                elements.canvas.width = img.naturalWidth || 512;
+                elements.canvas.height = img.naturalHeight || 512;
+                elements.canvas.getContext('2d').drawImage(img, 0, 0);
+                dataURL = elements.canvas.toDataURL('image/jpeg');
             }
-
-            const selectedMode = modeSelector.value;
-            let promptText = "";
-            if (selectedMode === 'custom') {
-                promptText = customPrompt.value;
-            } else {
-                promptText = modesData[selectedMode].prompt;
-            }
-
-            const galleryItem = document.createElement('li');
-            galleryItem.classList.add('isBusy');
-            const originalImage = document.createElement('img');
-            originalImage.src = dataURL;
-            galleryItem.appendChild(originalImage);
-            photoGallery.appendChild(galleryItem);
-            const emptyState = document.getElementById('empty-state');
-            if (emptyState) emptyState.remove();
-
-            fetch('/generate', {
+            
+            showProgressHud('Applying edit...');
+            
+            const modesData = JSON.parse(document.getElementById('modes-data').textContent);
+            const promptText = state.selectedMode === 'custom' ? state.customPrompt : modesData[state.selectedMode].prompt;
+            
+            const generationPromise = fetch('/generate', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    image: dataURL,
-                    prompt: promptText,
-                    mode: selectedMode
-                })
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ image: dataURL, prompt: promptText, mode: state.selectedMode })
             })
-            .then(async response => {
-                if (!response.ok) {
-                    const err = await response.json().catch(() => ({ error: 'Server error' }));
-                    throw new Error(err.error || 'Image generation failed');
-                }
-                return response.json();
-            })
-            .then(data => {
-                galleryItem.classList.remove('isBusy');
-                galleryItem.innerHTML = '';
+            .then(res => res.ok ? res.json() : res.json().then(err => Promise.reject(new Error(err.error))));
 
-                const inputContainer = document.createElement('div');
-                inputContainer.classList.add('photo');
-                const inputImage = document.createElement('img');
-                inputImage.src = data.input_url;
-                inputImage.alt = 'Original photo';
-                inputContainer.appendChild(inputImage);
+            const timerPromise = new Promise(resolve => setTimeout(resolve, 10000));
 
-                const outputContainer = document.createElement('div');
-                outputContainer.classList.add('photo');
-                if (data.output_url) {
-                  const generatedImage = document.createElement('img');
-                  generatedImage.src = data.output_url;
-                  generatedImage.alt = 'Generated photo';
-                  outputContainer.appendChild(generatedImage);
-                  const actions = document.createElement('div');
-                  actions.className = 'photo-actions';
-                  const dl = document.createElement('a');
-                  dl.href = data.output_url;
-                  dl.download = '';
-                  dl.className = 'button';
-                  dl.innerHTML = '<span class="icon">download</span>';
-                  actions.appendChild(dl);
-                  outputContainer.appendChild(actions);
-                } else {
-                  const errorMsg = document.createElement('div');
-                  errorMsg.style.padding = '10px';
-                  errorMsg.style.whiteSpace = 'pre-wrap';
-                  errorMsg.style.fontSize = '14px';
-                  errorMsg.style.color = '#f66';
-                  errorMsg.textContent = data.error || 'No image returned by model. Retry.';
-                  outputContainer.appendChild(errorMsg);
-                }
-
-                galleryItem.appendChild(inputContainer);
-                galleryItem.appendChild(outputContainer);
-
-                const emoji = document.createElement('p');
-                emoji.classList.add('emoji');
-                emoji.innerText = data.emoji;
-                galleryItem.appendChild(emoji);
-
-                photos.push(data.id);
-
-                const openLightbox = (src) => {
-                  const lb = document.getElementById('lightbox');
-                  const lbImg = document.getElementById('lightbox-img');
-                  const lbDl = document.getElementById('lightbox-download');
-                  lbImg.src = src;
-                  lbDl.href = src;
-                  lb.style.display = 'flex';
-                  lb.classList.add('is-open');
-                  lb.setAttribute('aria-hidden', 'false');
-                };
-                inputImage.addEventListener('click', () => openLightbox(inputImage.src));
-                const genImg = outputContainer.querySelector('img');
-                if (genImg) genImg.addEventListener('click', () => openLightbox(genImg.src));
+            Promise.all([generationPromise, timerPromise])
+            .then(([data, _]) => {
+                hideProgressHud();
+                addToGallery(data);
+                showToast('Image generated successfully!', 'success');
+                switchScreen('gallery');
             })
             .catch(err => {
-                galleryItem.classList.remove('isBusy');
-                galleryItem.innerHTML = '';
-                const errorMsg = document.createElement('div');
-                errorMsg.style.color = '#f66';
-                if (err.message && err.message.includes('download')) {
-                  errorMsg.textContent = 'Model download failed. Retry • Manage storage.';
-                } else {
-                  errorMsg.textContent = `Error: ${err.message}. Retry.`;
-                }
-                galleryItem.appendChild(errorMsg);
+                hideProgressHud();
+                showToast(err.message || 'Image generation failed', 'error');
             });
-        });
+        }
+        
+        function addToGallery(photoData) {
+            if (elements.emptyState) elements.emptyState.remove();
+            
+            const li = document.createElement('li');
+            li.className = 'gallery-item';
+            li.dataset.id = photoData.id;
+            
+            const img = document.createElement('img');
+            img.className = 'gallery-item-image';
+            img.src = photoData.output_url;
+            img.alt = 'Generated photo';
+            
+            const badge = document.createElement('div');
+            badge.className = 'gallery-item-badge';
+            badge.textContent = photoData.emoji;
+            
+            li.append(img, badge);
+            li.addEventListener('click', () => handleGalleryItemClick(photoData, li));
+            elements.photoGallery.appendChild(li);
+            state.photos.push(photoData);
+        }
 
-        makeGifButton.addEventListener('click', () => {
+        function handleGalleryItemClick(photoData, itemElement) {
+            if (state.isSelectMode) {
+                const photoId = photoData.id;
+                const index = state.selectedPhotos.indexOf(photoId);
+
+                if (index > -1) {
+                    state.selectedPhotos.splice(index, 1);
+                    itemElement.classList.remove('gallery-item-selected');
+                } else {
+                    state.selectedPhotos.push(photoId);
+                    itemElement.classList.add('gallery-item-selected');
+                }
+                elements.createGifBtn.style.display = state.selectedPhotos.length > 1 ? 'flex' : 'none';
+            } else {
+                openDetailView(photoData);
+            }
+        }
+
+        function toggleSelectMode() {
+            state.isSelectMode = !state.isSelectMode;
+            elements.galleryScreen.classList.toggle('is-select-mode', state.isSelectMode);
+            elements.createGifBtn.style.display = 'none';
+
+            if (!state.isSelectMode) {
+                state.selectedPhotos = [];
+                document.querySelectorAll('.gallery-item-selected').forEach(el => el.classList.remove('gallery-item-selected'));
+            }
+        }
+
+        function createGif() {
+            if (state.selectedPhotos.length < 2) {
+                showToast('Select at least 2 photos to create a GIF.', 'error');
+                return;
+            }
+            showProgressHud('Creating GIF...');
             fetch('/make_gif', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ photo_ids: photos })
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ photo_ids: state.selectedPhotos })
             })
-            .then(async response => {
-                if (!response.ok) {
-                    const err = await response.json().catch(() => ({ error: 'Server error' }));
-                    throw new Error(err.error || 'Failed to make GIF');
-                }
-                return response.json();
-            })
+            .then(res => res.ok ? res.json() : Promise.reject('Failed to create GIF'))
             .then(data => {
-                const gifImage = document.createElement('img');
-                gifImage.src = data.gif_url;
-                gifResult.innerHTML = '';
-                gifResult.appendChild(gifImage);
+                hideProgressHud();
+                const newPhotoData = {
+                    id: `gif-${Date.now()}`,
+                    output_url: data.gif_url,
+                    input_url: data.gif_url,
+                    emoji: '🎬',
+                    isGif: true
+                };
+                addToGallery(newPhotoData);
+                toggleSelectMode();
+                showToast('GIF created successfully!', 'success');
             })
             .catch(err => {
-                gifResult.textContent = `Error: ${err.message}. Retry.`;
+                hideProgressHud();
+                showToast(err, 'error');
             });
-        });
-
-    </script>
-    <script>
-      (function(){
-        const lb = document.getElementById('lightbox');
-        const closeBtn = document.getElementById('lightbox-close');
-        function close(){
-          lb.classList.remove('is-open');
-          lb.setAttribute('aria-hidden', 'true');
-          lb.style.display = 'none';
         }
-        closeBtn.addEventListener('click', close);
-        lb.addEventListener('click', (e) => {
-          if (e.target === lb) close();
-        });
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') close();
-        });
-      })();
+        
+        function selectMode(mode) {
+            state.selectedMode = mode;
+            updateModeSelection();
+            elements.customPromptContainer.style.display = mode === 'custom' ? 'block' : 'none';
+            if (mode === 'custom') elements.customPrompt.focus();
+        }
+        
+        function updateModeSelection() {
+            document.querySelectorAll('.mode-chip').forEach(chip => {
+                chip.classList.toggle('chip--selected', chip.dataset.mode === state.selectedMode);
+            });
+        }
+        
+        function switchScreen(screen) {
+            state.currentScreen = screen;
+            const screens = [elements.captureScreen, elements.galleryScreen, elements.exportScreen];
+            const target = document.getElementById(`${screen}-screen`);
+            
+            screens.forEach(s => {
+                if (s !== target && s.style.display !== 'none') {
+                    s.classList.remove('is-active');
+                    s.addEventListener('transitionend', () => s.style.display = 'none', { once: true });
+                }
+            });
+
+            target.style.display = 'flex';
+            requestAnimationFrame(() => target.classList.add('is-active'));
+
+            elements.navItems.forEach(item => {
+                item.classList.toggle('is-active', item.dataset.screen === screen);
+            });
+
+            if (elements.detailView.classList.contains('is-open')) closeDetailView();
+        }
+        
+        function openDetailView(photoData) {
+            if (photoData.isGif) {
+                state.currentDetailPhoto = photoData;
+                elements.detailImage.src = photoData.output_url;
+                elements.toggleOriginal.style.display = 'none';
+                elements.toggleEdited.style.display = 'none';
+                elements.detailView.classList.add('is-open');
+            } else {
+                state.currentDetailPhoto = photoData;
+                state.isDetailOriginal = false;
+                updateDetailView();
+                elements.toggleOriginal.style.display = '';
+                elements.toggleEdited.style.display = '';
+                elements.detailView.classList.add('is-open');
+            }
+        }
+        
+        function updateDetailView() {
+            if (!state.currentDetailPhoto) return;
+            const isOriginal = state.isDetailOriginal;
+            elements.detailImage.src = isOriginal ? state.currentDetailPhoto.input_url : state.currentDetailPhoto.output_url;
+            elements.toggleOriginal.classList.toggle('is-active', isOriginal);
+            elements.toggleEdited.classList.toggle('is-active', !isOriginal);
+        }
+        
+        function closeDetailView() {
+            elements.detailView.classList.remove('is-open');
+            state.currentDetailPhoto = null;
+        }
+        
+        function downloadDetailImage() {
+            if (!state.currentDetailPhoto) return;
+            const url = state.isDetailOriginal ? state.currentDetailPhoto.input_url : state.currentDetailPhoto.output_url;
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `gembooth-${state.currentDetailPhoto.id}.png`;
+            link.click();
+            showToast('Image downloaded!', 'success');
+        }
+        
+        function showToast(message, type = 'info') {
+            if (toastTimer) clearTimeout(toastTimer);
+            
+            elements.toastContent.textContent = message;
+            elements.toast.className = 'toast'; // Reset classes
+            elements.toast.classList.add(`toast--${type}`);
+
+            if (type === 'success') {
+                elements.toastIcon.textContent = 'check_circle';
+            } else if (type === 'error') {
+                elements.toastIcon.textContent = 'error';
+            } else {
+                elements.toastIcon.textContent = 'info';
+            }
+            
+            elements.toast.classList.add('is-visible');
+
+            toastTimer = setTimeout(hideToast, 4000);
+        }
+        
+        function hideToast() {
+            elements.toast.classList.remove('is-visible');
+            if (toastTimer) {
+                clearTimeout(toastTimer);
+                toastTimer = null;
+            }
+        }
+        
+        function showProgressHud(text, subtext = '') {
+            elements.progressText.textContent = text;
+            elements.progressSubtext.textContent = subtext;
+            elements.progressHud.classList.add('is-visible');
+
+            let percentage = 0;
+            const percentageElement = document.getElementById('progress-percentage');
+            percentageElement.textContent = '0%';
+
+            if (percentageCounterInterval) clearInterval(percentageCounterInterval);
+
+            percentageCounterInterval = setInterval(() => {
+                percentage++;
+                if (percentage <= 100) {
+                    percentageElement.textContent = `${percentage}%`;
+                } else {
+                    clearInterval(percentageCounterInterval);
+                }
+            }, 100);
+        }
+        
+        function hideProgressHud() {
+            elements.progressHud.classList.remove('is-visible');
+            if (percentageCounterInterval) {
+                clearInterval(percentageCounterInterval);
+                percentageCounterInterval = null;
+            }
+        }
+        
+        document.addEventListener('DOMContentLoaded', init);
     </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,59 +1,58 @@
-
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gembooth</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <script id="modes-data" type="application/json">{{ modes | tojson }}</script>
 </head>
 <body>
-    <main>
-        <div class="video-container">
+    <main class="app">
+        <section class="preview">
             <video id="video" autoplay playsinline></video>
             <img id="upload-preview" alt="Preview" style="display:none; max-width:100%; max-height:100%; object-fit:contain;" />
             <canvas id="canvas" style="display:none;"></canvas>
-            <button id="snap" class="shutter" aria-label="Take photo">
-                <span class="icon">camera</span>
-            </button>
-            <div style="position:absolute; top:10px; left:10px; display:flex; gap:8px;">
+            <div class="source-controls">
               <button id="toggle-source" class="button" title="Switch source" aria-label="Switch source">
-                <span class="icon">switch_camera</span> <span id="source-label">Camera</span>
+                <span class="icon">switch_camera</span><span id="source-label">Camera</span>
               </button>
-              <label class="button" for="file-input" id="upload-label" style="display:none; border:1px solid #444; padding:6px 10px; border-radius:6px;" aria-label="Import photo">
-                <span class="icon">upload</span> Import photo
+              <label class="button" for="file-input" id="upload-label" aria-label="Import photo" style="display:none;">
+                <span class="icon">upload</span>Import
               </label>
               <input id="file-input" type="file" accept="image/*" style="display:none;" />
             </div>
-        </div>
-        <div class="controls">
-            <select id="mode">
+            <button id="snap" class="shutter" aria-label="Take photo">
+                <span class="icon">photo_camera</span>
+            </button>
+        </section>
+        <section class="controls">
+            <select id="mode" aria-label="Style">
                 {% for key, value in modes.items() %}
                     <option value="{{ key }}">{{ value.emoji }} {{ value.name }}</option>
                 {% endfor %}
                 <option value="custom">✏️ Custom</option>
             </select>
-            <textarea id="custom-prompt" placeholder="Enter custom prompt" style="display:none;"></textarea>
-        </div>
-        <div class="results">
+            <textarea id="custom-prompt" placeholder="Describe your style" aria-label="Custom prompt" style="display:none;"></textarea>
+        </section>
+        <section class="gallery">
             <ul id="photo-gallery"><li id="empty-state" class="empty">Let’s make something. Take a photo or import one.</li></ul>
-        </div>
-        <div class="gif-container">
+        </section>
+        <section class="export">
             <button id="make-gif" class="button button--primary">Create GIF</button>
             <div id="gif-result"></div>
-        </div>
+        </section>
     </main>
 
-    <!-- Fullscreen lightbox for viewing images -->
     <div id="lightbox" class="lightbox" aria-hidden="true" style="display:none;">
-      <button id="lightbox-close" class="lightbox-close" aria-label="Close">×</button>
+      <button id="lightbox-close" class="lightbox-close" aria-label="Close"><span class="icon">close</span></button>
       <img id="lightbox-img" alt="Full view" />
       <div class="lightbox-actions">
         <a id="lightbox-download" class="button" href="#" download>
-          <span class="icon">download</span> Download
+          <span class="icon">download</span>Download
         </a>
       </div>
     </div>
@@ -78,7 +77,6 @@
         let captureSource = 'camera'; // 'camera' | 'upload'
         let stream = null;
 
-        // Get access to the camera
         async function startCamera() {
           if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) return;
           try {
@@ -86,7 +84,6 @@
             video.srcObject = stream;
             await video.play();
           } catch (e) {
-            // If user blocks camera, switch to upload mode
             captureSource = 'upload';
             updateSourceUI();
           }
@@ -132,10 +129,8 @@
           };
           reader.readAsDataURL(file);
         });
-        // Initial UI state
         updateSourceUI();
 
-        // Handle mode selection
         modeSelector.addEventListener('change', () => {
             if (modeSelector.value === 'custom') {
                 customPrompt.style.display = 'block';
@@ -144,7 +139,6 @@
             }
         });
 
-        // Capture a photo
         snap.addEventListener('click', function() {
             let dataURL;
             if (captureSource === 'camera') {
@@ -158,7 +152,6 @@
                     alert('Please choose an image to upload');
                     return;
                 }
-                // Draw upload image to canvas to normalize format/size
                 const img = uploadPreview;
                 const w = img.naturalWidth || 512;
                 const h = img.naturalHeight || 512;
@@ -167,7 +160,7 @@
                 canvas.getContext('2d').drawImage(img, 0, 0, w, h);
                 dataURL = canvas.toDataURL('image/jpeg');
             }
-            
+
             const selectedMode = modeSelector.value;
             let promptText = "";
             if (selectedMode === 'custom') {
@@ -176,7 +169,6 @@
                 promptText = modesData[selectedMode].prompt;
             }
 
-            // Show a loading indicator
             const galleryItem = document.createElement('li');
             galleryItem.classList.add('isBusy');
             const originalImage = document.createElement('img');
@@ -186,14 +178,13 @@
             const emptyState = document.getElementById('empty-state');
             if (emptyState) emptyState.remove();
 
-
             fetch('/generate', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ 
-                    image: dataURL, 
+                body: JSON.stringify({
+                    image: dataURL,
                     prompt: promptText,
                     mode: selectedMode
                 })
@@ -207,15 +198,15 @@
             })
             .then(data => {
                 galleryItem.classList.remove('isBusy');
-                galleryItem.innerHTML = ''; // Clear loading indicator
-                
+                galleryItem.innerHTML = '';
+
                 const inputContainer = document.createElement('div');
                 inputContainer.classList.add('photo');
                 const inputImage = document.createElement('img');
                 inputImage.src = data.input_url;
                 inputImage.alt = 'Original photo';
                 inputContainer.appendChild(inputImage);
-                
+
                 const outputContainer = document.createElement('div');
                 outputContainer.classList.add('photo');
                 if (data.output_url) {
@@ -223,7 +214,6 @@
                   generatedImage.src = data.output_url;
                   generatedImage.alt = 'Generated photo';
                   outputContainer.appendChild(generatedImage);
-                  // Quick action: download
                   const actions = document.createElement('div');
                   actions.className = 'photo-actions';
                   const dl = document.createElement('a');
@@ -253,7 +243,6 @@
 
                 photos.push(data.id);
 
-                // Enable full-view on click
                 const openLightbox = (src) => {
                   const lb = document.getElementById('lightbox');
                   const lbImg = document.getElementById('lightbox-img');
@@ -282,7 +271,6 @@
             });
         });
 
-        // Make a GIF
         makeGifButton.addEventListener('click', () => {
             fetch('/make_gif', {
                 method: 'POST',
@@ -311,7 +299,6 @@
 
     </script>
     <script>
-      // Lightbox interactions
       (function(){
         const lb = document.getElementById('lightbox');
         const closeBtn = document.getElementById('lightbox-close');

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gembooth</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <script id="modes-data" type="application/json">{{ modes | tojson }}</script>
@@ -15,15 +16,15 @@
             <video id="video" autoplay playsinline></video>
             <img id="upload-preview" alt="Preview" style="display:none; max-width:100%; max-height:100%; object-fit:contain;" />
             <canvas id="canvas" style="display:none;"></canvas>
-            <button id="snap" class="shutter">
+            <button id="snap" class="shutter" aria-label="Take photo">
                 <span class="icon">camera</span>
             </button>
             <div style="position:absolute; top:10px; left:10px; display:flex; gap:8px;">
-              <button id="toggle-source" class="button" title="Switch camera/upload">
+              <button id="toggle-source" class="button" title="Switch source" aria-label="Switch source">
                 <span class="icon">switch_camera</span> <span id="source-label">Camera</span>
               </button>
-              <label class="button" for="file-input" id="upload-label" style="display:none; border:1px solid #444; padding:6px 10px; border-radius:6px;">
-                <span class="icon">upload</span> Choose Image
+              <label class="button" for="file-input" id="upload-label" style="display:none; border:1px solid #444; padding:6px 10px; border-radius:6px;" aria-label="Import photo">
+                <span class="icon">upload</span> Import photo
               </label>
               <input id="file-input" type="file" accept="image/*" style="display:none;" />
             </div>
@@ -38,10 +39,10 @@
             <textarea id="custom-prompt" placeholder="Enter custom prompt" style="display:none;"></textarea>
         </div>
         <div class="results">
-            <ul id="photo-gallery"></ul>
+            <ul id="photo-gallery"><li id="empty-state" class="empty">Let’s make something. Take a photo or import one.</li></ul>
         </div>
         <div class="gif-container">
-            <button id="make-gif">Make GIF</button>
+            <button id="make-gif" class="button button--primary">Create GIF</button>
             <div id="gif-result"></div>
         </div>
     </main>
@@ -182,6 +183,8 @@
             originalImage.src = dataURL;
             galleryItem.appendChild(originalImage);
             photoGallery.appendChild(galleryItem);
+            const emptyState = document.getElementById('empty-state');
+            if (emptyState) emptyState.remove();
 
 
             fetch('/generate', {
@@ -198,7 +201,7 @@
             .then(async response => {
                 if (!response.ok) {
                     const err = await response.json().catch(() => ({ error: 'Server error' }));
-                    throw new Error(err.error || 'Failed to generate image');
+                    throw new Error(err.error || 'Image generation failed');
                 }
                 return response.json();
             })
@@ -236,7 +239,7 @@
                   errorMsg.style.whiteSpace = 'pre-wrap';
                   errorMsg.style.fontSize = '14px';
                   errorMsg.style.color = '#f66';
-                  errorMsg.textContent = data.error || 'No image returned by model';
+                  errorMsg.textContent = data.error || 'No image returned by model. Retry.';
                   outputContainer.appendChild(errorMsg);
                 }
 
@@ -270,7 +273,11 @@
                 galleryItem.innerHTML = '';
                 const errorMsg = document.createElement('div');
                 errorMsg.style.color = '#f66';
-                errorMsg.textContent = `Error: ${err.message}`;
+                if (err.message && err.message.includes('download')) {
+                  errorMsg.textContent = 'Model download failed. Retry • Manage storage.';
+                } else {
+                  errorMsg.textContent = `Error: ${err.message}. Retry.`;
+                }
                 galleryItem.appendChild(errorMsg);
             });
         });
@@ -298,7 +305,7 @@
                 gifResult.appendChild(gifImage);
             })
             .catch(err => {
-                gifResult.textContent = `Error: ${err.message}`;
+                gifResult.textContent = `Error: ${err.message}. Retry.`;
             });
         });
 


### PR DESCRIPTION
## Summary
- introduce theme tokens for color, spacing, type and component states
- polish capture flow markup with accessible labels and empty state
- document microcopy in a copy deck
- drop binary mockup assets and ignore them going forward

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a6a172bc8326ac86e9fa5256019c